### PR TITLE
Add inline tool result previews in tool step rows

### DIFF
--- a/Wisp/Models/Claude/ChatMessage.swift
+++ b/Wisp/Models/Claude/ChatMessage.swift
@@ -174,4 +174,15 @@ final class ToolResultCard: Identifiable {
             return content.prettyString
         }
     }
+
+    var previewContent: String? {
+        let text = displayContent
+        guard !text.isEmpty, text.count <= 500 else { return nil }
+        let lines = text.components(separatedBy: "\n").prefix(2)
+        let preview = lines.joined(separator: "\n")
+        if preview.count > 120 {
+            return String(preview.prefix(120)) + "..."
+        }
+        return preview
+    }
 }

--- a/Wisp/Views/SpriteDetail/Chat/ToolStepRow.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ToolStepRow.swift
@@ -6,29 +6,39 @@ struct ToolStepRow: View {
 
     var body: some View {
         Button(action: onTap) {
-            HStack(spacing: 6) {
-                Image(systemName: card.iconName)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 16)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Image(systemName: card.iconName)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 16)
 
-                Text(strippedLabel)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                    Text(strippedLabel)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
 
-                Spacer()
+                    Spacer()
 
-                if let elapsed = card.elapsedString {
-                    Text(elapsed)
-                        .font(.system(.caption2, design: .monospaced))
-                        .foregroundStyle(.tertiary)
+                    if let elapsed = card.elapsedString {
+                        Text(elapsed)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                    }
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.quaternary)
                 }
 
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 9))
-                    .foregroundStyle(.quaternary)
+                if let preview = card.result?.previewContent {
+                    Text(preview)
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(2)
+                        .padding(.leading, 22)
+                }
             }
             .contentShape(Rectangle())
             .padding(.vertical, 2)


### PR DESCRIPTION
## Summary

> Depends on #7 (thinking-shimmer) -- merge that first

- **ChatMessage.previewContent**: Computed property on `ToolResultCard` that extracts a brief preview string from tool results (file paths for Read/Write, command snippets for Bash, match counts for Grep/Glob)
- **ToolStepRow**: Shows the preview text below the tool label in a secondary caption, giving users a quick glance at what each tool did

## Test plan

- [ ] Merge #7 first
- [ ] Bash tool steps show a snippet of the command output
- [ ] Read/Write steps show the file path
- [ ] Grep/Glob steps show match count
- [ ] Steps with no result show no preview (graceful fallback)
- [ ] Tapping still opens the full detail sheet