### PR TITLE
Fix streaming/typing indicator sync: single source of truth

### DIFF
--- a/Wisp/Models/Claude/ChatMessage.swift
+++ b/Wisp/Models/Claude/ChatMessage.swift
@@ -13,16 +13,14 @@ final class ChatMessage: Identifiable {
     let timestamp: Date
     let role: ChatRole
     var content: [ChatContent]
-    var isStreaming: Bool
     var checkpointId: String?
     var checkpointComment: String?
 
-    init(id: UUID = UUID(), timestamp: Date = Date(), role: ChatRole, content: [ChatContent] = [], isStreaming: Bool = false, checkpointId: String? = nil, checkpointComment: String? = nil) {
+    init(id: UUID = UUID(), timestamp: Date = Date(), role: ChatRole, content: [ChatContent] = [], checkpointId: String? = nil, checkpointComment: String? = nil) {
         self.id = id
         self.timestamp = timestamp
         self.role = role
         self.content = content
-        self.isStreaming = isStreaming
         self.checkpointId = checkpointId
         self.checkpointComment = checkpointComment
     }

--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -76,6 +76,12 @@ final class ChatViewModel {
         return nil
     }
 
+    /// The ID of the message currently being built by a streaming response.
+    /// Views use this alongside `isStreaming` to show typing indicators on the right bubble.
+    var currentAssistantMessageId: UUID? {
+        currentAssistantMessage?.id
+    }
+
     func loadSession(apiClient: SpritesAPIClient, modelContext: ModelContext) {
         self.apiClient = apiClient
         guard let chat = fetchChat(modelContext: modelContext) else { return }
@@ -372,9 +378,6 @@ final class ChatViewModel {
         streamTask?.cancel()
         streamTask = nil
 
-        if let msg = currentAssistantMessage {
-            msg.isStreaming = false
-        }
         currentAssistantMessage = nil
         status = .idle
 
@@ -510,7 +513,7 @@ final class ChatViewModel {
             config: config
         )
 
-        let assistantMessage = ChatMessage(role: .assistant, isStreaming: true)
+        let assistantMessage = ChatMessage(role: .assistant)
         messages.append(assistantMessage)
         currentAssistantMessage = assistantMessage
 
@@ -522,7 +525,6 @@ final class ChatViewModel {
         // The reconnect task now owns the assistant message and shared state.
         guard !Task.isCancelled else { return }
 
-        assistantMessage.isStreaming = false
         if currentAssistantMessage?.id == assistantMessage.id {
             currentAssistantMessage = nil
         }
@@ -765,14 +767,12 @@ final class ChatViewModel {
         if let existing = currentAssistantMessage {
             assistantMessage = existing
             if !hasPriorEvents { assistantMessage.content = [] }
-            assistantMessage.isStreaming = true
         } else if let last = messages.last(where: { $0.role == .assistant }) {
             assistantMessage = last
             if !hasPriorEvents { assistantMessage.content = [] }
-            assistantMessage.isStreaming = true
             currentAssistantMessage = last
         } else {
-            assistantMessage = ChatMessage(role: .assistant, isStreaming: true)
+            assistantMessage = ChatMessage(role: .assistant)
             messages.append(assistantMessage)
             currentAssistantMessage = assistantMessage
         }
@@ -825,7 +825,6 @@ final class ChatViewModel {
         }
 
         // Finalize
-        assistantMessage.isStreaming = false
         if currentAssistantMessage?.id == assistantMessage.id {
             currentAssistantMessage = nil
         }
@@ -912,7 +911,6 @@ final class ChatViewModel {
                 logger.error("Claude result error: \(resultEvent.result ?? "unknown", privacy: .public)")
             }
             receivedResultEvent = true
-            currentAssistantMessage?.isStreaming = false
             sessionId = resultEvent.sessionId
             saveSession(modelContext: modelContext)
 

--- a/Wisp/Views/SpriteDetail/Chat/AssistantMessageView.swift
+++ b/Wisp/Views/SpriteDetail/Chat/AssistantMessageView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct AssistantMessageView: View {
     let message: ChatMessage
+    var isStreaming: Bool = false
     var onCreateCheckpoint: (() -> Void)? = nil
     var isCheckpointDisabled: Bool = false
     @State private var selectedToolCard: ToolUseCard?
@@ -10,7 +11,7 @@ struct AssistantMessageView: View {
     private var canCheckpoint: Bool {
         onCreateCheckpoint != nil
             && message.checkpointId == nil
-            && !message.isStreaming
+            && !isStreaming
     }
 
     var body: some View {
@@ -47,7 +48,7 @@ struct AssistantMessageView: View {
                             ToolStepRow(card: card) {
                                 selectedToolCard = card
                             }
-                        } else if !message.isStreaming {
+                        } else if !isStreaming {
                             // Cancelled/incomplete tool (not streaming) -- muted row
                             HStack(spacing: 6) {
                                 Image(systemName: card.iconName)
@@ -73,6 +74,7 @@ struct AssistantMessageView: View {
                             .background(Color.red.opacity(0.1), in: RoundedRectangle(cornerRadius: 12))
                     }
                 }
+
             }
             Spacer(minLength: 60)
         }

--- a/Wisp/Views/SpriteDetail/Chat/ChatMessageView.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatMessageView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ChatMessageView: View {
     let message: ChatMessage
+    var isStreaming: Bool = false
     var onCreateCheckpoint: (() -> Void)? = nil
     var isCheckpointDisabled: Bool = false
 
@@ -12,6 +13,7 @@ struct ChatMessageView: View {
         case .assistant:
             AssistantMessageView(
                 message: message,
+                isStreaming: isStreaming,
                 onCreateCheckpoint: onCreateCheckpoint,
                 isCheckpointDisabled: isCheckpointDisabled
             )

--- a/Wisp/Views/SpriteDetail/Chat/ChatView.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatView.swift
@@ -44,7 +44,7 @@ struct ChatView: View {
                 proxy.scrollTo("bottom")
             }
             .onChange(of: viewModel.messages.last?.content.count) {
-                if viewModel.messages.last?.isStreaming == true {
+                if viewModel.isStreaming {
                     proxy.scrollTo("bottom")
                 }
             }
@@ -121,6 +121,7 @@ struct ChatView: View {
             && message.id == viewModel.messages.last(where: { $0.role == .assistant })?.id
         ChatMessageView(
             message: message,
+            isStreaming: viewModel.isStreaming && message.id == viewModel.currentAssistantMessageId,
             onCreateCheckpoint: isLastAssistant ? {
                 viewModel.createCheckpoint(for: message, modelContext: modelContext)
             } : nil,

--- a/WispTests/ChatViewModelTests.swift
+++ b/WispTests/ChatViewModelTests.swift
@@ -32,7 +32,7 @@ struct ChatViewModelTests {
         let ctx = try makeModelContext()
         let (vm, _) = makeChatViewModel(modelContext: ctx)
 
-        let msg = ChatMessage(role: .assistant, isStreaming: true)
+        let msg = ChatMessage(role: .assistant)
         vm.messages.append(msg)
         vm.setCurrentAssistantMessage(msg)
 
@@ -50,7 +50,7 @@ struct ChatViewModelTests {
         let ctx = try makeModelContext()
         let (vm, _) = makeChatViewModel(modelContext: ctx)
 
-        let msg = ChatMessage(role: .assistant, isStreaming: true)
+        let msg = ChatMessage(role: .assistant)
         vm.messages.append(msg)
         vm.setCurrentAssistantMessage(msg)
 
@@ -72,7 +72,7 @@ struct ChatViewModelTests {
         let ctx = try makeModelContext()
         let (vm, _) = makeChatViewModel(modelContext: ctx)
 
-        let msg = ChatMessage(role: .assistant, isStreaming: true)
+        let msg = ChatMessage(role: .assistant)
         vm.messages.append(msg)
         vm.setCurrentAssistantMessage(msg)
 
@@ -101,7 +101,7 @@ struct ChatViewModelTests {
         let ctx = try makeModelContext()
         let (vm, _) = makeChatViewModel(modelContext: ctx)
 
-        let msg = ChatMessage(role: .assistant, isStreaming: true)
+        let msg = ChatMessage(role: .assistant)
         vm.messages.append(msg)
         vm.setCurrentAssistantMessage(msg)
 
@@ -128,7 +128,7 @@ struct ChatViewModelTests {
         let ctx = try makeModelContext()
         let (vm, _) = makeChatViewModel(modelContext: ctx)
 
-        let msg = ChatMessage(role: .assistant, isStreaming: true)
+        let msg = ChatMessage(role: .assistant)
         vm.messages.append(msg)
         vm.setCurrentAssistantMessage(msg)
 
@@ -165,7 +165,7 @@ struct ChatViewModelTests {
         let ctx = try makeModelContext()
         let (vm, _) = makeChatViewModel(modelContext: ctx)
 
-        let msg = ChatMessage(role: .assistant, isStreaming: true)
+        let msg = ChatMessage(role: .assistant)
         vm.messages.append(msg)
         vm.setCurrentAssistantMessage(msg)
 
@@ -207,7 +207,7 @@ struct ChatViewModelTests {
         let ctx = try makeModelContext()
         let (vm, _) = makeChatViewModel(modelContext: ctx)
 
-        let msg = ChatMessage(role: .assistant, isStreaming: true)
+        let msg = ChatMessage(role: .assistant)
         vm.messages.append(msg)
         vm.setCurrentAssistantMessage(msg)
 
@@ -227,7 +227,7 @@ struct ChatViewModelTests {
         let ctx = try makeModelContext()
         let (vm, _) = makeChatViewModel(modelContext: ctx)
 
-        let msg = ChatMessage(role: .assistant, isStreaming: true)
+        let msg = ChatMessage(role: .assistant)
         vm.messages.append(msg)
         vm.setCurrentAssistantMessage(msg)
 
@@ -412,22 +412,22 @@ struct ChatViewModelTests {
         }
     }
 
-    // MARK: - handleEvent: result
+    // MARK: - Streaming state (single source of truth)
 
-    @Test func handleEvent_resultClearsStreaming() throws {
+    @Test func currentAssistantMessageId_tracksCurrentMessage() throws {
         let ctx = try makeModelContext()
         let (vm, _) = makeChatViewModel(modelContext: ctx)
 
-        let msg = ChatMessage(role: .assistant, isStreaming: true)
+        #expect(vm.currentAssistantMessageId == nil)
+
+        let msg = ChatMessage(role: .assistant)
         vm.messages.append(msg)
         vm.setCurrentAssistantMessage(msg)
 
-        let event = ClaudeStreamEvent.result(ClaudeResultEvent(
-            type: "result", subtype: "success", sessionId: "sess-1",
-            isError: nil, durationMs: 1000, numTurns: 1, result: nil
-        ))
-        vm.handleEvent(event, modelContext: ctx)
+        #expect(vm.currentAssistantMessageId == msg.id)
 
-        #expect(msg.isStreaming == false)
+        vm.setCurrentAssistantMessage(nil)
+
+        #expect(vm.currentAssistantMessageId == nil)
     }
 }


### PR DESCRIPTION
## Summary

- `ChatMessage.isStreaming` and `ChatViewModel.status` were two independent `@Observable` properties on **different objects**, both tracking whether Claude was actively streaming
- Because SwiftUI observation tracks each object separately, changes could land in different render passes — causing the status bar and typing dots to briefly show inconsistent state
- There's no legitimate case where they should differ: both represent the same concept

## Fix

Remove `isStreaming` from `ChatMessage` entirely. The typing-dots indicator is now derived in the view layer as a single computed expression:

```swift
viewModel.isStreaming && message.id == viewModel.currentAssistantMessageId
```

`ChatViewModel` exposes a new `currentAssistantMessageId: UUID?` computed property (backed by the existing private `currentAssistantMessage`). All mutations to `message.isStreaming` in `ChatViewModel` are removed.

## Files changed

- `ChatMessage.swift` — remove `isStreaming` property
- `ChatViewModel.swift` — add `currentAssistantMessageId`, remove all `message.isStreaming = ...` mutations  
- `AssistantMessageView.swift` + `ChatMessageView.swift` — add `isStreaming: Bool` parameter, threaded down from `ChatView`
- `ChatView.swift` — compute `isStreaming` per message; simplify scroll `onChange` to use `viewModel.isStreaming`
- `ChatViewModelTests.swift` — replace `handleEvent_resultClearsStreaming` with `currentAssistantMessageId_tracksCurrentMessage`

## Test plan

- [ ] Build and run tests: `xcodebuild -scheme Wisp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' test`
- [ ] Send a message, verify typing dots and status bar appear and disappear together
- [ ] Interrupt a stream, verify both clear immediately
- [ ] Background/foreground during a stream (reconnect path), verify no desync

🤖 Generated with [Claude Code](https://claude.com/claude-code)