### PR TITLE
Add swipe-to-dismiss on queued message bubble

### DIFF
--- a/Wisp/Views/SpriteDetail/Chat/PendingUserBubbleView.swift
+++ b/Wisp/Views/SpriteDetail/Chat/PendingUserBubbleView.swift
@@ -6,9 +6,10 @@ struct PendingUserBubbleView: View {
     let onCancel: () -> Void
 
     @State private var dragOffset: CGFloat = 0
-    @GestureState private var isDragging = false
 
     private let dismissThreshold: CGFloat = 80
+    private let dismissOffset: CGFloat = 400
+    private let dismissDuration: TimeInterval = 0.2
 
     var body: some View {
         HStack {
@@ -38,9 +39,6 @@ struct PendingUserBubbleView: View {
         .opacity(1 - Double(min(abs(dragOffset) / dismissThreshold, 1)) * 0.5)
         .gesture(
             DragGesture(minimumDistance: 20)
-                .updating($isDragging) { _, state, _ in
-                    state = true
-                }
                 .onChanged { value in
                     if value.translation.width > 0 {
                         dragOffset = value.translation.width
@@ -48,10 +46,11 @@ struct PendingUserBubbleView: View {
                 }
                 .onEnded { value in
                     if value.translation.width > dismissThreshold {
-                        withAnimation(.easeOut(duration: 0.2)) {
-                            dragOffset = 400
+                        withAnimation(.easeOut(duration: dismissDuration)) {
+                            dragOffset = dismissOffset
                         }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        Task {
+                            try? await Task.sleep(for: .seconds(dismissDuration))
                             onCancel()
                         }
                     } else {


### PR DESCRIPTION
## Summary

- Add right-swipe gesture to dismiss the queued message bubble, complementing the existing edit/cancel icon buttons

Rebased on current main -- single-file, 32-line diff. Replaces #25.

## Test plan

- [ ] Queue a message while streaming -- bubble appears with edit/cancel buttons
- [ ] Swipe the bubble to the right -- it fades, slides off, and the queued message is cancelled
- [ ] Swipe partway and release -- bubble springs back to original position
- [ ] Edit and cancel buttons still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)