### PR TITLE
Show "Connecting…" in typing indicator while connecting

### DIFF
--- a/Wisp/Views/SpriteDetail/Chat/ChatView.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatView.swift
@@ -30,7 +30,7 @@ struct ChatView: View {
                         messageView(message)
                     }
                     if viewModel.isStreaming && viewModel.pendingWispAskCard == nil {
-                        ThinkingShimmerView(label: viewModel.activeToolLabel ?? "Thinking...")
+                        ThinkingShimmerView(label: viewModel.status.isConnecting ? "Connecting…" : (viewModel.activeToolLabel ?? "Thinking…"))
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                             .id("shimmer")
                     }


### PR DESCRIPTION
## Summary

- When the chat is in `.connecting` state, the `ThinkingShimmerView` now displays "Connecting…" instead of "Thinking…"
- Once the connection is established and we're in `.streaming` state, it shows the active tool label or falls back to "Thinking…" as before

## Change

One-line change in `ChatView.swift` — uses the existing `status.isConnecting` computed property on `ChatStatus` to pick the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)