### PR TITLE
Sanitize shell interpolations to prevent injection

### DIFF
--- a/Wisp.xcodeproj/project.pbxproj
+++ b/Wisp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		61CBE460AC96CBE6BF8AF0B0 /* SpriteSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BE6E0D68BBB35DE56600E1 /* SpriteSession.swift */; };
 		6445AB5A4723D213CFDF0460 /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3893EEF3ADDA05DF7A9C0909 /* JSONValue.swift */; };
 		6D0E6C856F514B6E4F81313C /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F53154EEA09CE101C7703 /* AppError.swift */; };
+		A1B2C3D4E5F60001DEADBEEF /* ShellEscaping.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002DEADBEEF /* ShellEscaping.swift */; };
 		6F12D7D1F6C0AAFE6C28AB4C /* ClaudeEventTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B299898C61EA80D1A91AF37 /* ClaudeEventTypes.swift */; };
 		735DA590AAB4728F7A8B5037 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4C3A1F2B2D57313431E50 /* Extensions.swift */; };
 		760347D84B9D49623B0A5BC5 /* AssistantMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E3CEEE606D9AFF4265AB76 /* AssistantMessageView.swift */; };
@@ -196,6 +197,7 @@
 		AB04F3FB6C647DE1F6DC0FD0 /* ToolInputDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolInputDetailView.swift; sourceTree = "<group>"; };
 		AC9BFD0F0AC39C136C9E828A /* SpriteOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteOverviewViewModel.swift; sourceTree = "<group>"; };
 		AE09C632E049BE561A702FDF /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60002DEADBEEF /* ShellEscaping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEscaping.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A70819304B5C6D /* SpriteChatMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteChatMigration.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7081930DBFF01 /* SessionSuggestionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSuggestionsView.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A3 /* WebViewPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewPage.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 				C8C4C3A1F2B2D57313431E50 /* Extensions.swift */,
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* InAppBrowserCoordinator.swift */,
 				3893EEF3ADDA05DF7A9C0909 /* JSONValue.swift */,
+				A1B2C3D4E5F60002DEADBEEF /* ShellEscaping.swift */,
 				B2C3D4E5F6A70819304B5C6D /* SpriteChatMigration.swift */,
 			);
 			path = Utilities;
@@ -764,6 +767,7 @@
 				974996B0FB4D30828E89DD21 /* SpriteOverviewViewModel.swift in Sources */,
 				0418F9D619251B7E6DB0276F /* SpriteRowView.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5E /* SpriteChat.swift in Sources */,
+				A1B2C3D4E5F60001DEADBEEF /* ShellEscaping.swift in Sources */,
 				B2C3D4E5F6A70819304B5C6E /* SpriteChatMigration.swift in Sources */,
 				C3D4E5F6A7B80920415C6D7F /* SpriteChatListViewModel.swift in Sources */,
 				D4E5F6A7B8C90A31526D7E90 /* ChatSwitcherSheet.swift in Sources */,

--- a/Wisp/Services/ClaudeQuestionTool.swift
+++ b/Wisp/Services/ClaudeQuestionTool.swift
@@ -156,15 +156,21 @@ enum ClaudeQuestionTool {
     static let versionPath = "/home/sprite/.wisp/claude-question/version"
 
     // Per-session helpers — each chat uses its own files so concurrent sessions don't conflict
+    static func sanitizedSessionId(_ sessionId: String) -> String {
+        // Only allow alphanumeric, hyphens, and underscores
+        sessionId.filter { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }
+    }
+
     static func mcpConfigJSON(for sessionId: String) -> String {
-        #"{"mcpServers":{"askUser":{"command":"python3","args":["/home/sprite/.wisp/claude-question/server.py"],"env":{"WISP_SESSION_ID":""# + sessionId + #""}}}}"#
+        let safe = sanitizedSessionId(sessionId)
+        return #"{"mcpServers":{"askUser":{"command":"python3","args":["/home/sprite/.wisp/claude-question/server.py"],"env":{"WISP_SESSION_ID":""# + safe + #""}}}}"#
     }
 
     static func mcpConfigFilePath(for sessionId: String) -> String {
-        "/tmp/.wisp_mcp_\(sessionId).json"
+        "/tmp/.wisp_mcp_\(sanitizedSessionId(sessionId)).json"
     }
 
     static func responseFilePath(for sessionId: String) -> String {
-        "/tmp/.wisp_ask_response_\(sessionId).json"
+        "/tmp/.wisp_ask_response_\(sanitizedSessionId(sessionId)).json"
     }
 }

--- a/Wisp/Utilities/ShellEscaping.swift
+++ b/Wisp/Utilities/ShellEscaping.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Shell-escapes a string for safe interpolation into single-quoted shell arguments.
+/// Replaces each `'` with `'\''` (end quote, escaped quote, start quote).
+func shellEscape(_ value: String) -> String {
+    "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}

--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -1560,14 +1560,6 @@ final class ChatViewModel {
 
     // MARK: - Worktrees
 
-    /// Returns a POSIX single-quoted shell argument with any internal single quotes escaped.
-    /// Single quotes have no escape sequence in POSIX shell, so the idiom is:
-    /// close the quote, insert a backslash-escaped literal quote, then reopen.
-    /// e.g. "it's here" → "'it'\\''s here'"
-    static func shellEscapePath(_ s: String) -> String {
-        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
-
     /// Converts a chat name to a kebab-case git branch name.
     /// e.g. "Add dark mode" → "add-dark-mode"
     static func branchName(from chatName: String) -> String {
@@ -1598,10 +1590,10 @@ final class ChatViewModel {
         worktreeDir: String,
         uniqueBranchName: String
     ) -> String {
-        let qWorkDir = shellEscapePath(currentWorkDir)
-        let qWorktreeParent = shellEscapePath(worktreeParent)
-        let qWorktreeDir = shellEscapePath(worktreeDir)
-        let qBranch = shellEscapePath(uniqueBranchName)
+        let qWorkDir = shellEscape(currentWorkDir)
+        let qWorktreeParent = shellEscape(worktreeParent)
+        let qWorktreeDir = shellEscape(worktreeDir)
+        let qBranch = shellEscape(uniqueBranchName)
 
         return """
         git config --global --add safe.directory '*' 2>/dev/null; \
@@ -1684,7 +1676,7 @@ final class ChatViewModel {
             let newPath = worktree.hasSuffix("/") ? worktree + filename : worktree + "/" + filename
             guard attachment.path != newPath else { continue }
             copyJobs.append((index: i, newPath: newPath))
-            copyCommands.append("cp \(Self.shellEscapePath(attachment.path)) \(Self.shellEscapePath(newPath)) 2>/dev/null && echo ok || echo skip")
+            copyCommands.append("cp \(shellEscape(attachment.path)) \(shellEscape(newPath)) 2>/dev/null && echo ok || echo skip")
         }
 
         guard !copyJobs.isEmpty else { return attachments }

--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -775,26 +775,21 @@ final class ChatViewModel {
             }
         }
 
-        let escapedPrompt = fullPrompt
-            .replacingOccurrences(of: "'", with: "'\\''")
-
         // Build the full bash -c command with env vars inlined
         var commandParts: [String] = [
-            "export CLAUDE_CODE_OAUTH_TOKEN='\(claudeToken)'",
+            "export CLAUDE_CODE_OAUTH_TOKEN=\(shellEscape(claudeToken))",
             "export NO_DNA=1", // Signal to CLIs that they're running under an agent operator (no-dna.org)
-            "mkdir -p \(workingDirectory)",
-            "cd \(workingDirectory)",
+            "mkdir -p \(shellEscape(workingDirectory))",
+            "cd \(shellEscape(workingDirectory))",
         ]
 
         let gitName = UserDefaults.standard.string(forKey: "gitName") ?? ""
         let gitEmail = UserDefaults.standard.string(forKey: "gitEmail") ?? ""
         if !gitName.isEmpty {
-            let escapedName = gitName.replacingOccurrences(of: "'", with: "'\\''")
-            commandParts.append("git config --global user.name '\(escapedName)'")
+            commandParts.append("git config --global user.name \(shellEscape(gitName))")
         }
         if !gitEmail.isEmpty {
-            let escapedEmail = gitEmail.replacingOccurrences(of: "'", with: "'\\''")
-            commandParts.append("git config --global user.email '\(escapedEmail)'")
+            commandParts.append("git config --global user.email \(shellEscape(gitEmail))")
         }
 
         var claudeCmd = "claude -p --verbose --output-format stream-json --dangerously-skip-permissions"
@@ -802,9 +797,9 @@ final class ChatViewModel {
             let sessionId = chatId.uuidString.lowercased()
             let configPath = ClaudeQuestionTool.mcpConfigFilePath(for: sessionId)
             // Write per-session MCP config (inlined in the command chain so no extra round-trip)
-            commandParts.append("echo '\(ClaudeQuestionTool.mcpConfigJSON(for: sessionId))' > \(configPath)")
+            commandParts.append("echo \(shellEscape(ClaudeQuestionTool.mcpConfigJSON(for: sessionId))) > \(shellEscape(configPath))")
             claudeCmd += " --disallowedTools AskUserQuestion"
-            claudeCmd += " --mcp-config \(configPath)"
+            claudeCmd += " --mcp-config \(shellEscape(configPath))"
         }
 
         let modelId = modelOverride?.rawValue ?? UserDefaults.standard.string(forKey: "claudeModel") ?? ClaudeModel.sonnet.rawValue
@@ -817,15 +812,14 @@ final class ChatViewModel {
 
         let customInstructions = UserDefaults.standard.string(forKey: "customInstructions") ?? ""
         if !customInstructions.isEmpty {
-            let escapedInstructions = customInstructions.replacingOccurrences(of: "'", with: "'\\''")
-            claudeCmd += " --append-system-prompt '\(escapedInstructions)'"
+            claudeCmd += " --append-system-prompt \(shellEscape(customInstructions))"
         }
 
         usedResume = sessionId != nil
         if let sessionId {
-            claudeCmd += " --resume \(sessionId)"
+            claudeCmd += " --resume \(shellEscape(sessionId))"
         }
-        claudeCmd += " '\(escapedPrompt)'"
+        claudeCmd += " \(shellEscape(fullPrompt))"
 
         // Wrap claude with a heartbeat so the sprite stays alive while Claude
         // is waiting for an API response and Wisp is detached. The heartbeat

--- a/Wisp/ViewModels/SpriteOverviewViewModel.swift
+++ b/Wisp/ViewModels/SpriteOverviewViewModel.swift
@@ -114,7 +114,7 @@ final class SpriteOverviewViewModel {
         isAuthenticatingGitHub = true
         _ = await apiClient.runExec(
             spriteName: sprite.name,
-            command: "printf '%s' '\(ghToken)' | gh auth login --with-token && gh auth setup-git"
+            command: "printf '%s' \(shellEscape(ghToken)) | gh auth login --with-token && gh auth setup-git"
         )
         isAuthenticatingGitHub = false
         await checkGitHubAuth(apiClient: apiClient)
@@ -274,7 +274,7 @@ final class SpriteOverviewViewModel {
         isAuthenticatingSprites = true
         _ = await apiClient.runExec(
             spriteName: sprite.name,
-            command: "sprite auth setup --token '\(token)'"
+            command: "sprite auth setup --token \(shellEscape(token))"
         )
         isAuthenticatingSprites = false
         await checkSpritesAuth(apiClient: apiClient)

--- a/WispTests/WorktreeTests.swift
+++ b/WispTests/WorktreeTests.swift
@@ -26,23 +26,23 @@ struct WorktreeTests {
         )
     }
 
-    // MARK: - shellEscapePath
+    // MARK: - shellEscape
 
-    @Test func shellEscapePath_plainPath() {
-        #expect(ChatViewModel.shellEscapePath("/home/sprite/project/file.txt") == "'/home/sprite/project/file.txt'")
+    @Test func shellEscape_plainPath() {
+        #expect(shellEscape("/home/sprite/project/file.txt") == "'/home/sprite/project/file.txt'")
     }
 
-    @Test func shellEscapePath_pathWithSingleQuote() {
+    @Test func shellEscape_pathWithSingleQuote() {
         // "it's.txt" → 'it'\''s.txt'
-        #expect(ChatViewModel.shellEscapePath("/home/sprite/it's.txt") == "'/home/sprite/it'\\''s.txt'")
+        #expect(shellEscape("/home/sprite/it's.txt") == "'/home/sprite/it'\\''s.txt'")
     }
 
-    @Test func shellEscapePath_pathWithSpaces() {
-        #expect(ChatViewModel.shellEscapePath("/home/sprite/my file.txt") == "'/home/sprite/my file.txt'")
+    @Test func shellEscape_pathWithSpaces() {
+        #expect(shellEscape("/home/sprite/my file.txt") == "'/home/sprite/my file.txt'")
     }
 
-    @Test func shellEscapePath_empty() {
-        #expect(ChatViewModel.shellEscapePath("") == "''")
+    @Test func shellEscape_empty() {
+        #expect(shellEscape("") == "''")
     }
 
     // MARK: - copyAttachmentsToWorktree


### PR DESCRIPTION
## Summary
- Adds a `shellEscape()` utility that wraps values in single quotes with proper escaping
- Applies it to all shell command construction in `ChatViewModel` (workingDirectory, tokens, sessionId, MCP config paths, prompts, git name/email, custom instructions)
- Applies it to `SpriteOverviewViewModel` (GitHub token auth, Sprites CLI token auth)  
- Adds `sanitizedSessionId()` to `ClaudeQuestionTool` that strips non-alphanumeric characters from sessionId before using it in file paths and JSON

Previously, `workingDirectory`, `sessionId`, `configPath`, and tokens were interpolated directly into shell commands without escaping. While exploitation risk is low (values come from controlled sources), defense-in-depth is warranted for shell command construction.

## Test plan
- [ ] Verify chat messaging still works end-to-end (send message, receive response)
- [ ] Verify MCP question tool installs and works
- [ ] Verify GitHub and Sprites CLI auth from overview screen
- [ ] Verify git name/email with special characters (e.g., apostrophes) works

Generated with [Claude Code](https://claude.com/claude-code)