### PR TITLE
Move New Chat button to top of overview Chats section

### DIFF
--- a/Wisp/Views/SpriteDetail/Overview/SpriteOverviewView.swift
+++ b/Wisp/Views/SpriteDetail/Overview/SpriteOverviewView.swift
@@ -42,13 +42,14 @@ struct SpriteOverviewView: View {
         List {
             if let chatListVM = chatListViewModel {
                 Section("Chats") {
-                    ForEach(chatListVM.chats, id: \.id) { chat in
-                        chatRow(for: chat, in: chatListVM)
-                    }
                     Button {
                         onNewChat?()
                     } label: {
                         Label("New Chat", systemImage: "square.and.pencil")
+                    }
+                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                    ForEach(chatListVM.chats, id: \.id) { chat in
+                        chatRow(for: chat, in: chatListVM)
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Moves the "New Chat" button to the top of the Chats section in `SpriteOverviewView`, so it appears before existing chats rather than after them

🤖 Generated with [Claude Code](https://claude.com/claude-code)