### PR TITLE
Show reconnecting state immediately on chat open

### DIFF
--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -715,6 +715,12 @@ final class ChatViewModel {
             return
         }
 
+        // Optimistically show reconnecting immediately — local state already tells us
+        // the session wasn't complete, so no need to wait for the task to start before
+        // the UI reflects that we're reconnecting. reattachToExec also sets this, but
+        // setting synchronously here avoids a brief idle flash while the Task warms up.
+        status = .reconnecting
+
         // Cancel any orphaned task that may still be running (e.g., from a concurrent
         // call to reconnectIfNeeded triggered by both DashboardView startup and
         // resumeAllAfterBackground before the first task had a chance to set .reconnecting).


### PR DESCRIPTION
## Summary

- Set `status = .reconnecting` synchronously in `reconnectIfNeeded` before the `getServiceStatus` network call, so the UI transitions away from idle immediately when local state already indicates an incomplete session
- Reset `status = .idle` in the "service never existed" guard path to compensate for the optimistic set

## Why

Previously the chat would sit in `.idle` (showing the model picker) until the `getServiceStatus` API call returned, then transition to `.reconnecting`. Since local state (`lastSessionComplete == false`) already tells us a reconnect is needed, we can show the right UI state instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)