### PR TITLE
Fix delete confirmation dialog dismissing immediately in chat list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Phase 1 scope — build only these features:
 - Tool use cards are collapsible/expandable inline elements between chat bubbles
 - Show loading states for Sprite wake-up ("Waking Sprite..." for cold starts, ~1s)
 - Destructive actions (delete Sprite, restore checkpoint) always require confirmation dialogs
+- **Presentation modifiers in lists**: Never attach `.confirmationDialog`, `.alert`, or `.sheet` to rows inside a `ForEach`. Attach them to the `List` (or another stable ancestor view) instead, using a single `isPresented: Binding(get: { item != nil }, set: { if !$0 { item = nil } })` pattern. Attaching to `ForEach` rows causes the dialog to dismiss itself immediately when the list re-renders.
 
 ### Multi-platform layout (iPhone / iPad / Mac)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ Phase 1 scope — build only these features:
 - Show loading states for Sprite wake-up ("Waking Sprite..." for cold starts, ~1s)
 - Destructive actions (delete Sprite, restore checkpoint) always require confirmation dialogs
 - **Presentation modifiers in lists**: Never attach `.confirmationDialog`, `.alert`, or `.sheet` to rows inside a `ForEach`. Attach them to the `List` (or another stable ancestor view) instead, using a single `isPresented: Binding(get: { item != nil }, set: { if !$0 { item = nil } })` pattern. Attaching to `ForEach` rows causes the dialog to dismiss itself immediately when the list re-renders.
+- **Destructive row confirmations on iPad/Mac**: Prefer `.alert` over `.confirmationDialog` for row-level destructive confirmations in views that can render in a regular horizontal size class (e.g. `NavigationSplitView` detail columns like `SpriteOverviewView`). In regular size class `.confirmationDialog` becomes a popover anchored to its host view — attached to the `List` it points at the whole list instead of the swiped row, and attaching per-row re-introduces the dismiss bug. `.alert` is a centered modal with no anchoring and works identically across size classes. `.confirmationDialog` is still fine inside sheets (e.g. `ChatSwitcherSheet`), which run in a compact-ish presentation environment internally.
 
 ### Multi-platform layout (iPhone / iPad / Mac)
 

--- a/Wisp/Views/SpriteDetail/Chat/ChatSwitcherSheet.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatSwitcherSheet.swift
@@ -94,23 +94,25 @@ struct ChatSwitcherSheet: View {
                             .tint(.orange)
                         }
                     }
-                    .confirmationDialog(
-                        "Delete Chat",
-                        isPresented: Binding(
-                            get: { chatToDelete?.id == chat.id },
-                            set: { if !$0 { chatToDelete = nil } }
-                        ),
-                        titleVisibility: .visible
-                    ) {
-                        Button("Delete", role: .destructive) {
-                            chatSessionManager.remove(chatId: chat.id, modelContext: modelContext)
-                            viewModel.deleteChat(chat, apiClient: apiClient, modelContext: modelContext)
-                            chatToDelete = nil
-                        }
-                    } message: {
-                        Text("This will permanently delete the chat and its history.")
+                }
+            }
+            .confirmationDialog(
+                "Delete Chat",
+                isPresented: Binding(
+                    get: { chatToDelete != nil },
+                    set: { if !$0 { chatToDelete = nil } }
+                ),
+                titleVisibility: .visible
+            ) {
+                Button("Delete", role: .destructive) {
+                    if let chat = chatToDelete {
+                        chatSessionManager.remove(chatId: chat.id, modelContext: modelContext)
+                        viewModel.deleteChat(chat, apiClient: apiClient, modelContext: modelContext)
+                        chatToDelete = nil
                     }
                 }
+            } message: {
+                Text("This will permanently delete the chat and its history.")
             }
             .navigationTitle("Chats")
             .navigationBarTitleDisplayMode(.inline)

--- a/Wisp/Views/SpriteDetail/Overview/SpriteOverviewView.swift
+++ b/Wisp/Views/SpriteDetail/Overview/SpriteOverviewView.swift
@@ -381,6 +381,24 @@ struct SpriteOverviewView: View {
                 }
             }
         }
+        .confirmationDialog(
+            "Delete Chat",
+            isPresented: Binding(
+                get: { chatToDelete != nil },
+                set: { if !$0 { chatToDelete = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let chat = chatToDelete, let chatListVM = chatListViewModel {
+                    chatSessionManager.remove(chatId: chat.id, modelContext: modelContext)
+                    chatListVM.deleteChat(chat, apiClient: apiClient, modelContext: modelContext)
+                    chatToDelete = nil
+                }
+            }
+        } message: {
+            Text("This will permanently delete the chat and its history.")
+        }
         .refreshable {
             await viewModel.refresh(apiClient: apiClient)
         }
@@ -585,22 +603,6 @@ struct SpriteOverviewView: View {
             } label: {
                 Label("Delete", systemImage: "trash")
             }
-        }
-        .confirmationDialog(
-            "Delete Chat",
-            isPresented: Binding(
-                get: { chatToDelete?.id == chat.id },
-                set: { if !$0 { chatToDelete = nil } }
-            ),
-            titleVisibility: .visible
-        ) {
-            Button("Delete", role: .destructive) {
-                chatSessionManager.remove(chatId: chat.id, modelContext: modelContext)
-                chatListVM.deleteChat(chat, apiClient: apiClient, modelContext: modelContext)
-                chatToDelete = nil
-            }
-        } message: {
-            Text("This will permanently delete the chat and its history.")
         }
     }
 

--- a/Wisp/Views/SpriteDetail/Overview/SpriteOverviewView.swift
+++ b/Wisp/Views/SpriteDetail/Overview/SpriteOverviewView.swift
@@ -381,22 +381,25 @@ struct SpriteOverviewView: View {
                 }
             }
         }
-        .confirmationDialog(
+        .alert(
             "Delete Chat",
             isPresented: Binding(
                 get: { chatToDelete != nil },
                 set: { if !$0 { chatToDelete = nil } }
             ),
-            titleVisibility: .visible
-        ) {
+            presenting: chatToDelete
+        ) { chat in
             Button("Delete", role: .destructive) {
-                if let chat = chatToDelete, let chatListVM = chatListViewModel {
+                if let chatListVM = chatListViewModel {
                     chatSessionManager.remove(chatId: chat.id, modelContext: modelContext)
                     chatListVM.deleteChat(chat, apiClient: apiClient, modelContext: modelContext)
-                    chatToDelete = nil
                 }
+                chatToDelete = nil
             }
-        } message: {
+            Button("Cancel", role: .cancel) {
+                chatToDelete = nil
+            }
+        } message: { _ in
             Text("This will permanently delete the chat and its history.")
         }
         .refreshable {


### PR DESCRIPTION
## Summary
- `.confirmationDialog` was attached to each row inside the `ForEach` in `ChatSwitcherSheet`. Any list re-render (triggered by `@Observable` reacting to the `chatToDelete` state change) would dismiss the dialog immediately after it appeared.
- Moved the single `.confirmationDialog` to the `List`, with `isPresented: Binding(get: { chatToDelete != nil }, ...)` — a stable view that won't be re-created during list updates.
- Added a note to `CLAUDE.md` documenting this pattern to prevent recurrence.

## Test plan
- [ ] Swipe to delete a chat — confirmation dialog stays visible until tapped
- [ ] Tap Delete in the dialog — chat is removed
- [ ] Tap Cancel — dialog dismisses, chat is unchanged
- [ ] Context menu Delete — same behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)