### PR TITLE
Fix pending message lost when stopping current response

### DIFF
--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -646,15 +646,34 @@ final class ChatViewModel {
     }
 
     func interrupt(apiClient: SpritesAPIClient? = nil, modelContext: ModelContext? = nil) {
+        let savedPrompt = queuedPrompt
+        let savedAttachments = queuedAttachments
+
         detach(modelContext: modelContext)
 
         // Note: we keep sessionId intact so the next message can resume the session.
         // If the session turns out to be stale, the stale-session retry logic handles it.
 
-        // Kill the exec session to stop it; clear execSessionId to prevent reconnect
+        // Kill the exec session to stop it; clear execSessionId to prevent reconnect.
         let execId = execSessionId
         execSessionId = nil
-        if let apiClient, let execId {
+
+        if let apiClient, let savedPrompt, let modelContext {
+            // A message was queued behind the interrupted stream — drain it after the kill
+            // so the user's pending input isn't silently discarded.
+            let sName = spriteName
+            let prompt = buildPrompt(text: savedPrompt, attachments: savedAttachments)
+            let userMessage = ChatMessage(role: .user, content: [.text(prompt)])
+            messages.append(userMessage)
+            persistMessages(modelContext: modelContext)
+            status = .connecting
+            streamTask = Task {
+                if let execId {
+                    try? await apiClient.killExecSession(spriteName: sName, execSessionId: execId)
+                }
+                await executeClaudeCommand(prompt: prompt, apiClient: apiClient, modelContext: modelContext)
+            }
+        } else if let apiClient, let execId {
             let sName = spriteName
             Task {
                 try? await apiClient.killExecSession(spriteName: sName, execSessionId: execId)

--- a/WispTests/ChatViewModelTests.swift
+++ b/WispTests/ChatViewModelTests.swift
@@ -557,6 +557,29 @@ struct ChatViewModelTests {
         }
     }
 
+    @Test func interrupt_withQueuedMessageAndAttachments_preservesAttachments() throws {
+        // Regression guard: detach() clears queuedAttachments, so interrupt() must capture
+        // them before detach or the attachment paths are silently dropped from the drained message.
+        let ctx = try makeModelContext()
+        let (vm, _) = makeChatViewModel(modelContext: ctx)
+        vm.status = .streaming
+        vm.queuedPrompt = "look at this"
+        vm.queuedAttachments = [AttachedFile(name: "notes.txt", path: "/home/sprite/project/notes.txt")]
+
+        vm.interrupt(apiClient: SpritesAPIClient(), modelContext: ctx)
+
+        #expect(vm.queuedPrompt == nil)
+        #expect(vm.queuedAttachments.isEmpty)
+        #expect(vm.messages.count == 1)
+        // buildPrompt prepends the attachment path to the text, so both should appear in the bubble
+        if case .text(let t) = vm.messages.first?.content.first {
+            #expect(t.contains("/home/sprite/project/notes.txt"))
+            #expect(t.contains("look at this"))
+        } else {
+            Issue.record("Expected text content in user message")
+        }
+    }
+
     // MARK: - processExecStream
 
     @Test func processExecStream_cleanCloseWithResultEvent_returnsCompleted() async throws {

--- a/WispTests/ChatViewModelTests.swift
+++ b/WispTests/ChatViewModelTests.swift
@@ -534,6 +534,29 @@ struct ChatViewModelTests {
         }
     }
 
+    @Test func interrupt_withQueuedMessage_appendsMessageAndStartsStream() throws {
+        let ctx = try makeModelContext()
+        let (vm, _) = makeChatViewModel(modelContext: ctx)
+        vm.status = .streaming
+        vm.queuedPrompt = "follow-up question"
+
+        vm.interrupt(apiClient: SpritesAPIClient(), modelContext: ctx)
+
+        // Queued prompt is consumed into the messages list
+        #expect(vm.queuedPrompt == nil)
+        #expect(vm.messages.count == 1)
+        #expect(vm.messages.first?.role == .user)
+        if case .text(let t) = vm.messages.first?.content.first {
+            #expect(t == "follow-up question")
+        } else {
+            Issue.record("Expected text content in user message")
+        }
+        // Status moves to .connecting as it starts sending the queued message
+        guard case .connecting = vm.status else {
+            Issue.record("Expected connecting status after interrupt with queued message"); return
+        }
+    }
+
     // MARK: - processExecStream
 
     @Test func processExecStream_cleanCloseWithResultEvent_returnsCompleted() async throws {


### PR DESCRIPTION
## Summary

- When a user taps Stop while a queued/pending message is waiting, `interrupt()` was calling `detach()` which unconditionally cleared `queuedPrompt` and `queuedAttachments`, silently discarding the pending message
- Fix saves the queued state before `detach()`, then after deleting the service, appends the user message and starts a new stream — matching the existing behaviour in `finishStream()` where a queued message automatically follows a completed response
- If there's no pending message (or no `apiClient`/`modelContext`), the original code path is preserved

## Test plan

- [ ] Added unit test `interrupt_withQueuedMessage_appendsMessageAndStartsStream` verifying the queued message is consumed into the messages list, `queuedPrompt` is cleared, and status moves to `.connecting`
- [ ] Manual: type a follow-up message while Claude is responding, hit Stop — the pending message should be sent automatically rather than disappearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)