### PR TITLE
Improve settings: copy tokens and edit without signing out

### DIFF
--- a/Wisp/Models/Claude/ClaudeModel.swift
+++ b/Wisp/Models/Claude/ClaudeModel.swift
@@ -1,5 +1,25 @@
 import Foundation
 
+enum ClaudeEffortLevel: String, CaseIterable, Identifiable {
+    case low
+    case medium
+    case high
+    case max
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .low: "Low"
+        case .medium: "Medium"
+        case .high: "High"
+        case .max: "Max"
+        }
+    }
+
+    var isDefault: Bool { self == .medium }
+}
+
 enum ClaudeModel: String, CaseIterable, Identifiable {
     case sonnet = "sonnet[1m]"
     case opus = "opus[1m]"

--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -49,6 +49,7 @@ final class ChatViewModel {
     var status: ChatStatus = .idle
     var modelName: String?
     var modelOverride: ClaudeModel?
+    var effortLevel: ClaudeEffortLevel = .medium
     var remoteSessions: [ClaudeSessionEntry] = []
     var hasAnyRemoteSessions = false
     var isLoadingRemoteSessions = false
@@ -756,6 +757,7 @@ final class ChatViewModel {
 
         let modelId = modelOverride?.rawValue ?? UserDefaults.standard.string(forKey: "claudeModel") ?? ClaudeModel.sonnet.rawValue
         claudeCmd += " --model \(modelId)"
+        claudeCmd += " --effort \(effortLevel.rawValue)"
 
         let maxTurns = UserDefaults.standard.integer(forKey: "maxTurns")
         if maxTurns > 0 {

--- a/Wisp/Views/Settings/EditTokenSheet.swift
+++ b/Wisp/Views/Settings/EditTokenSheet.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+struct EditTokenSheet: View {
+    enum TokenType {
+        case sprites
+        case claude
+
+        var title: String {
+            switch self {
+            case .sprites: "Update Sprites Token"
+            case .claude: "Update Claude Token"
+            }
+        }
+
+        var placeholder: String {
+            switch self {
+            case .sprites: "Sprites API Token"
+            case .claude: "Claude Code OAuth Token (sk-ant-oat01-...)"
+            }
+        }
+
+        var keychainKey: KeychainKey {
+            switch self {
+            case .sprites: .spritesToken
+            case .claude: .claudeToken
+            }
+        }
+
+        var needsValidation: Bool {
+            switch self {
+            case .sprites: true
+            case .claude: false
+            }
+        }
+    }
+
+    let tokenType: TokenType
+    @Binding var isPresented: Bool
+    @Environment(SpritesAPIClient.self) private var apiClient
+
+    @State private var token = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    private var saveButtonLabel: String {
+        tokenType.needsValidation ? "Validate & Save" : "Save"
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    SecureField(tokenType.placeholder, text: $token)
+                        .textContentType(.password)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                } footer: {
+                    if let errorMessage {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle(tokenType.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        isPresented = false
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(saveButtonLabel) {
+                        Task { await save() }
+                    }
+                    .disabled(token.isEmpty || isSaving)
+                    .overlay {
+                        if isSaving {
+                            ProgressView()
+                        }
+                    }
+                }
+            }
+            .disabled(isSaving)
+        }
+    }
+
+    private func save() async {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        errorMessage = nil
+
+        if tokenType.needsValidation {
+            isSaving = true
+            defer { isSaving = false }
+            do {
+                try KeychainService.shared.save(trimmed, for: tokenType.keychainKey)
+                apiClient.refreshAuthState()
+                try await apiClient.validateToken()
+                isPresented = false
+            } catch {
+                KeychainService.shared.delete(key: tokenType.keychainKey)
+                apiClient.refreshAuthState()
+                errorMessage = "Invalid token. Please check and try again."
+            }
+        } else {
+            do {
+                try KeychainService.shared.save(trimmed, for: tokenType.keychainKey)
+                apiClient.refreshAuthState()
+                isPresented = false
+            } catch {
+                errorMessage = "Failed to save token."
+            }
+        }
+    }
+}
+
+#Preview {
+    EditTokenSheet(tokenType: .claude, isPresented: .constant(true))
+        .environment(SpritesAPIClient())
+}

--- a/Wisp/Views/Settings/SettingsView.swift
+++ b/Wisp/Views/Settings/SettingsView.swift
@@ -15,6 +15,10 @@ struct SettingsView: View {
     @State private var showGitHubConnect = false
     @State private var showGitHubDisconnectConfirmation = false
     @State private var copiedTokenFlash = false
+    @State private var showEditSpritesToken = false
+    @State private var showEditClaudeToken = false
+    @State private var copiedSpritesFlash = false
+    @State private var copiedClaudeFlash = false
     #if DEBUG
     @State private var copiedDeviceIDFlash = false
     @State private var copiedCommitFlash = false
@@ -54,25 +58,75 @@ struct SettingsView: View {
         .sheet(isPresented: $showGitHubConnect) {
             GitHubConnectSheet()
         }
+        .sheet(isPresented: $showEditSpritesToken) {
+            EditTokenSheet(tokenType: .sprites, isPresented: $showEditSpritesToken)
+                .environment(apiClient)
+        }
+        .sheet(isPresented: $showEditClaudeToken) {
+            EditTokenSheet(tokenType: .claude, isPresented: $showEditClaudeToken)
+                .environment(apiClient)
+        }
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func tokenRow(
+        title: String,
+        icon: String,
+        isConnected: Bool,
+        token: String?,
+        copiedFlash: Binding<Bool>,
+        showEdit: Binding<Bool>
+    ) -> some View {
+        HStack {
+            Label(title, systemImage: icon)
+            Spacer()
+            Text(copiedFlash.wrappedValue ? "Copied!" : (isConnected ? "Connected" : "Disconnected"))
+                .foregroundStyle(copiedFlash.wrappedValue ? .green : (isConnected ? .green : .secondary))
+                .contentTransition(.numericText())
+        }
+        .contextMenu {
+            if isConnected, let token {
+                Button {
+                    UIPasteboard.general.string = token
+                    withAnimation { copiedFlash.wrappedValue = true }
+                    Task {
+                        try? await Task.sleep(for: .seconds(1.5))
+                        withAnimation { copiedFlash.wrappedValue = false }
+                    }
+                } label: {
+                    Label("Copy Token", systemImage: "doc.on.doc")
+                }
+            }
+            Button {
+                showEdit.wrappedValue = true
+            } label: {
+                Label("Update Token", systemImage: "pencil")
+            }
+        }
     }
 
     // MARK: - Sections
 
     private var accountSection: some View {
         Section("Account") {
-            HStack {
-                Label("Sprites API", systemImage: "server.rack")
-                Spacer()
-                Text(apiClient.isAuthenticated ? "Connected" : "Disconnected")
-                    .foregroundStyle(apiClient.isAuthenticated ? .green : .secondary)
-            }
-
-            HStack {
-                Label("Claude Code", systemImage: "brain")
-                Spacer()
-                Text(apiClient.hasClaudeToken ? "Connected" : "Disconnected")
-                    .foregroundStyle(apiClient.hasClaudeToken ? .green : .secondary)
-            }
+            tokenRow(
+                title: "Sprites API",
+                icon: "server.rack",
+                isConnected: apiClient.isAuthenticated,
+                token: apiClient.spritesToken,
+                copiedFlash: $copiedSpritesFlash,
+                showEdit: $showEditSpritesToken
+            )
+            tokenRow(
+                title: "Claude Code",
+                icon: "brain",
+                isConnected: apiClient.hasClaudeToken,
+                token: apiClient.claudeToken,
+                copiedFlash: $copiedClaudeFlash,
+                showEdit: $showEditClaudeToken
+            )
 
             HStack {
                 Label("GitHub", systemImage: "lock.shield")

--- a/Wisp/Views/SpriteDetail/Chat/ChatStatusBar.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatStatusBar.swift
@@ -4,6 +4,7 @@ struct ChatStatusBar: View {
     let status: ChatStatus
     let modelName: String?
     @Binding var modelOverride: ClaudeModel?
+    @Binding var effortLevel: ClaudeEffortLevel
     var hasPendingWispAsk: Bool = false
 
     @AppStorage("claudeModel") private var globalModel: String = ClaudeModel.sonnet.rawValue
@@ -71,18 +72,37 @@ struct ChatStatusBar: View {
 
     private var modelPicker: some View {
         Menu {
-            ForEach(ClaudeModel.allCases) { model in
-                Button {
-                    if model.rawValue == globalModel {
-                        modelOverride = nil
-                    } else {
-                        modelOverride = model
+            Section("Model") {
+                ForEach(ClaudeModel.allCases) { model in
+                    Button {
+                        if model.rawValue == globalModel {
+                            modelOverride = nil
+                        } else {
+                            modelOverride = model
+                        }
+                        if model != .opus && effortLevel == .max {
+                            effortLevel = .high
+                        }
+                    } label: {
+                        HStack {
+                            Text(model.displayName)
+                            if model == effectiveModel {
+                                Image(systemName: "checkmark")
+                            }
+                        }
                     }
-                } label: {
-                    HStack {
-                        Text(model.displayName)
-                        if model == effectiveModel {
-                            Image(systemName: "checkmark")
+                }
+            }
+            Section("Effort") {
+                ForEach(ClaudeEffortLevel.allCases.filter { $0 != .max || effectiveModel == .opus }) { level in
+                    Button {
+                        effortLevel = level
+                    } label: {
+                        HStack {
+                            Text(level.displayName)
+                            if level == effortLevel {
+                                Image(systemName: "checkmark")
+                            }
                         }
                     }
                 }
@@ -92,9 +112,15 @@ struct ChatStatusBar: View {
                 Image(systemName: "sparkle")
                     .foregroundStyle(.primary)
                     .font(.system(size: 9))
-                Text(effectiveModel.displayName)
-                    .font(.caption2)
-                    .foregroundStyle(.primary)
+                if effortLevel.isDefault {
+                    Text(effectiveModel.displayName)
+                        .font(.caption2)
+                        .foregroundStyle(.primary)
+                } else {
+                    Text("\(effectiveModel.displayName) · \(effortLevel.displayName)")
+                        .font(.caption2)
+                        .foregroundStyle(.primary)
+                }
                 Image(systemName: "chevron.up.chevron.down")
                     .foregroundStyle(.secondary)
                     .font(.system(size: 8))
@@ -111,35 +137,48 @@ private let previewBackground = LinearGradient(
 
 #Preview("Idle - Model Picker") {
     @Previewable @State var modelOverride: ClaudeModel? = nil
-    ChatStatusBar(status: .idle, modelName: "claude-sonnet-4-5-20250929", modelOverride: $modelOverride)
+    @Previewable @State var effortLevel: ClaudeEffortLevel = .medium
+    ChatStatusBar(status: .idle, modelName: "claude-sonnet-4-5-20250929", modelOverride: $modelOverride, effortLevel: $effortLevel)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(previewBackground)
+}
+
+#Preview("Idle - High Effort") {
+    @Previewable @State var modelOverride: ClaudeModel? = nil
+    @Previewable @State var effortLevel: ClaudeEffortLevel = .high
+    ChatStatusBar(status: .idle, modelName: "claude-sonnet-4-5-20250929", modelOverride: $modelOverride, effortLevel: $effortLevel)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(previewBackground)
 }
 
 #Preview("Streaming") {
     @Previewable @State var modelOverride: ClaudeModel? = nil
-    ChatStatusBar(status: .streaming, modelName: nil, modelOverride: $modelOverride)
+    @Previewable @State var effortLevel: ClaudeEffortLevel = .medium
+    ChatStatusBar(status: .streaming, modelName: nil, modelOverride: $modelOverride, effortLevel: $effortLevel)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(previewBackground)
 }
 
 #Preview("Connecting") {
     @Previewable @State var modelOverride: ClaudeModel? = nil
-    ChatStatusBar(status: .connecting, modelName: nil, modelOverride: $modelOverride)
+    @Previewable @State var effortLevel: ClaudeEffortLevel = .medium
+    ChatStatusBar(status: .connecting, modelName: nil, modelOverride: $modelOverride, effortLevel: $effortLevel)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(previewBackground)
 }
 
 #Preview("Reconnecting") {
     @Previewable @State var modelOverride: ClaudeModel? = nil
-    ChatStatusBar(status: .reconnecting, modelName: nil, modelOverride: $modelOverride)
+    @Previewable @State var effortLevel: ClaudeEffortLevel = .medium
+    ChatStatusBar(status: .reconnecting, modelName: nil, modelOverride: $modelOverride, effortLevel: $effortLevel)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(previewBackground)
 }
 
 #Preview("Error") {
     @Previewable @State var modelOverride: ClaudeModel? = nil
-    ChatStatusBar(status: .error("Connection lost"), modelName: nil, modelOverride: $modelOverride)
+    @Previewable @State var effortLevel: ClaudeEffortLevel = .medium
+    ChatStatusBar(status: .error("Connection lost"), modelName: nil, modelOverride: $modelOverride, effortLevel: $effortLevel)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(previewBackground)
 }
@@ -147,6 +186,7 @@ private let previewBackground = LinearGradient(
 #Preview("All States") {
     @Previewable @State var stateIndex = 0
     @Previewable @State var modelOverride: ClaudeModel? = nil
+    @Previewable @State var effortLevel: ClaudeEffortLevel = .medium
 
     let states: [(ChatStatus, String?)] = [
         (.connecting, nil),
@@ -160,7 +200,8 @@ private let previewBackground = LinearGradient(
         ChatStatusBar(
             status: states[stateIndex].0,
             modelName: states[stateIndex].1,
-            modelOverride: $modelOverride
+            modelOverride: $modelOverride,
+            effortLevel: $effortLevel
         )
 
         Button("Next State") {

--- a/Wisp/Views/SpriteDetail/Chat/ChatView.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatView.swift
@@ -103,6 +103,7 @@ struct ChatView: View {
                     status: viewModel.status,
                     modelName: viewModel.modelName,
                     modelOverride: Bindable(viewModel).modelOverride,
+                    effortLevel: Bindable(viewModel).effortLevel,
                     hasPendingWispAsk: viewModel.pendingWispAskCard != nil
                 )
             }

--- a/WispTests/ChatViewModelTests.swift
+++ b/WispTests/ChatViewModelTests.swift
@@ -53,6 +53,14 @@ struct ChatViewModelTests {
         }
     }
 
+    // MARK: - initial state
+
+    @Test func initialEffortLevelIsMedium() throws {
+        let ctx = try makeModelContext()
+        let (vm, _) = makeChatViewModel(modelContext: ctx)
+        #expect(vm.effortLevel == .medium)
+    }
+
     // MARK: - handleEvent: system
 
     @Test func handleEvent_systemSetsModelName() throws {

--- a/WispTests/ClaudeModelTests.swift
+++ b/WispTests/ClaudeModelTests.swift
@@ -1,6 +1,36 @@
 import Testing
 @testable import Wisp
 
+@Suite("ClaudeEffortLevel")
+struct ClaudeEffortLevelTests {
+
+    @Test func onlyMediumIsDefault() {
+        for level in ClaudeEffortLevel.allCases {
+            #expect(level.isDefault == (level == .medium))
+        }
+    }
+
+    @Test func allCasesHaveDisplayNames() {
+        #expect(ClaudeEffortLevel.low.displayName == "Low")
+        #expect(ClaudeEffortLevel.medium.displayName == "Medium")
+        #expect(ClaudeEffortLevel.high.displayName == "High")
+        #expect(ClaudeEffortLevel.max.displayName == "Max")
+    }
+
+    @Test func rawValuesMatchCLIFlag() {
+        #expect(ClaudeEffortLevel.low.rawValue == "low")
+        #expect(ClaudeEffortLevel.medium.rawValue == "medium")
+        #expect(ClaudeEffortLevel.high.rawValue == "high")
+        #expect(ClaudeEffortLevel.max.rawValue == "max")
+    }
+
+    @Test func identifiableUsesRawValue() {
+        for level in ClaudeEffortLevel.allCases {
+            #expect(level.id == level.rawValue)
+        }
+    }
+}
+
 @Suite("ClaudeModel")
 struct ClaudeModelTests {
 


### PR DESCRIPTION
## Summary

- Long-press (context menu) on **Sprites API** and **Claude Code** rows to copy the token to clipboard, with a "Copied!" flash
- **Update Token** option in the same context menu opens a focused sheet to replace just that token — no sign-out required
- Sprites token is validated against the API before saving; Claude token saves directly
- Shared `tokenRow` `@ViewBuilder` helper keeps the two rows DRY

## Test plan

- [ ] Long-press Sprites API row → "Copy Token" copies to clipboard and shows "Copied!" flash
- [ ] Long-press Claude Code row → same
- [ ] "Update Token" on Sprites API opens sheet; entering an invalid token shows error and does not save
- [ ] "Update Token" on Sprites API with valid token validates, saves, dismisses sheet, row shows "Connected"
- [ ] "Update Token" on Claude Code saves immediately without validation
- [ ] Both tokens update without requiring sign-out; existing sessions unaffected
- [ ] Cancel button dismisses sheet with no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)