### PR TITLE
Fetch origin before creating worktree branch

### DIFF
--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -1582,12 +1582,28 @@ final class ChatViewModel {
         let worktreeParent = "/home/sprite/.wisp/worktrees/\(repoName)"
         let worktreeDir = "\(worktreeParent)/\(uniqueBranchName)"
 
+        let qWorkDir = Self.shellEscapePath(currentWorkDir)
+        let qWorktreeParent = Self.shellEscapePath(worktreeParent)
+        let qWorktreeDir = Self.shellEscapePath(worktreeDir)
+        let qBranch = Self.shellEscapePath(uniqueBranchName)
+
         // Mark all directories as safe to avoid "dubious ownership" errors when the repo
         // is owned by a different uid than the running process (common on Sprites).
         // Fetch origin so the new branch starts from the latest remote state (failure is non-fatal).
+        // Resolve the remote's default branch via origin/HEAD (handles master, develop, etc.);
+        // `remote set-head --auto` populates it if it's not already set. Fall back to local HEAD
+        // if everything fails (no remote, offline and never fetched) — matches pre-PR behavior.
         // Prune stale worktree registrations (handles dirs deleted without `git worktree remove`).
         // Capture stderr from worktree add collapsed to one line so we can log it on failure.
-        let command = "git config --global --add safe.directory '*' 2>/dev/null; git -C '\(currentWorkDir)' fetch origin 2>/dev/null || true; git -C '\(currentWorkDir)' worktree prune 2>/dev/null; mkdir -p '\(worktreeParent)' && GTWT_OUT=$(git -C '\(currentWorkDir)' worktree add '\(worktreeDir)' -b '\(uniqueBranchName)' origin/main 2>&1); if [ $? -eq 0 ]; then echo '\(worktreeDir)'; else echo \"WORKTREE_ERR:$(echo $GTWT_OUT)\"; fi"
+        let command = """
+        git config --global --add safe.directory '*' 2>/dev/null; \
+        git -C \(qWorkDir) fetch origin 2>/dev/null || true; \
+        git -C \(qWorkDir) remote set-head origin --auto 2>/dev/null || true; \
+        BASE_REF=$(git -C \(qWorkDir) symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo HEAD); \
+        git -C \(qWorkDir) worktree prune 2>/dev/null; \
+        mkdir -p \(qWorktreeParent) && GTWT_OUT=$(git -C \(qWorkDir) worktree add \(qWorktreeDir) -b \(qBranch) "$BASE_REF" 2>&1); \
+        if [ $? -eq 0 ]; then echo \(qWorktreeDir); else echo "WORKTREE_ERR:$(echo $GTWT_OUT)"; fi
+        """
 
         let (output, _) = await apiClient.runExec(spriteName: spriteName, command: command, timeout: 60)
         // git worktree add may print "HEAD is now at..." to stdout before our echo,

--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -1584,9 +1584,10 @@ final class ChatViewModel {
 
         // Mark all directories as safe to avoid "dubious ownership" errors when the repo
         // is owned by a different uid than the running process (common on Sprites).
+        // Fetch origin so the new branch starts from the latest remote state (failure is non-fatal).
         // Prune stale worktree registrations (handles dirs deleted without `git worktree remove`).
         // Capture stderr from worktree add collapsed to one line so we can log it on failure.
-        let command = "git config --global --add safe.directory '*' 2>/dev/null; git -C '\(currentWorkDir)' pull 2>/dev/null || true; git -C '\(currentWorkDir)' worktree prune 2>/dev/null; mkdir -p '\(worktreeParent)' && GTWT_OUT=$(git -C '\(currentWorkDir)' worktree add '\(worktreeDir)' -b '\(uniqueBranchName)' 2>&1); if [ $? -eq 0 ]; then echo '\(worktreeDir)'; else echo \"WORKTREE_ERR:$(echo $GTWT_OUT)\"; fi"
+        let command = "git config --global --add safe.directory '*' 2>/dev/null; git -C '\(currentWorkDir)' fetch origin 2>/dev/null || true; git -C '\(currentWorkDir)' worktree prune 2>/dev/null; mkdir -p '\(worktreeParent)' && GTWT_OUT=$(git -C '\(currentWorkDir)' worktree add '\(worktreeDir)' -b '\(uniqueBranchName)' origin/main 2>&1); if [ $? -eq 0 ]; then echo '\(worktreeDir)'; else echo \"WORKTREE_ERR:$(echo $GTWT_OUT)\"; fi"
 
         let (output, _) = await apiClient.runExec(spriteName: spriteName, command: command, timeout: 60)
         // git worktree add may print "HEAD is now at..." to stdout before our echo,

--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -1567,6 +1567,40 @@ final class ChatViewModel {
         return kebab.isEmpty ? "chat" : String(kebab.prefix(50))
     }
 
+    /// Builds the shell command that creates a git worktree for a new chat branch.
+    ///
+    /// - Fetches origin so the new branch starts from the latest remote state (non-fatal on failure).
+    /// - Resolves the remote's default branch via `origin/HEAD` (handles master, develop, etc.);
+    ///   `remote set-head --auto` populates it if not already set. Falls back to local `HEAD` if
+    ///   everything fails (no remote, offline and never fetched).
+    /// - Marks all directories as safe to avoid "dubious ownership" errors when the repo is owned
+    ///   by a different uid than the running process (common on Sprites).
+    /// - Prunes stale worktree registrations (handles dirs deleted without `git worktree remove`).
+    /// - Echoes the worktree path on success, or `WORKTREE_ERR:<stderr>` on failure.
+    ///
+    /// Extracted as a pure function so it can be unit-tested without going through the async exec path.
+    static func buildWorktreeSetupCommand(
+        currentWorkDir: String,
+        worktreeParent: String,
+        worktreeDir: String,
+        uniqueBranchName: String
+    ) -> String {
+        let qWorkDir = shellEscapePath(currentWorkDir)
+        let qWorktreeParent = shellEscapePath(worktreeParent)
+        let qWorktreeDir = shellEscapePath(worktreeDir)
+        let qBranch = shellEscapePath(uniqueBranchName)
+
+        return """
+        git config --global --add safe.directory '*' 2>/dev/null; \
+        git -C \(qWorkDir) fetch origin 2>/dev/null || true; \
+        git -C \(qWorkDir) remote set-head origin --auto 2>/dev/null || true; \
+        BASE_REF=$(git -C \(qWorkDir) symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo HEAD); \
+        git -C \(qWorkDir) worktree prune 2>/dev/null; \
+        mkdir -p \(qWorktreeParent) && GTWT_OUT=$(git -C \(qWorkDir) worktree add \(qWorktreeDir) -b \(qBranch) "$BASE_REF" 2>&1); \
+        if [ $? -eq 0 ]; then echo \(qWorktreeDir); else echo "WORKTREE_ERR:$(echo $GTWT_OUT)"; fi
+        """
+    }
+
     /// Runs a preliminary exec to set up a git worktree for this chat.
     /// Updates `workingDirectory` and `worktreePath` if worktree creation succeeds.
     /// Silently skips if the working directory is not inside a git repo.
@@ -1582,28 +1616,12 @@ final class ChatViewModel {
         let worktreeParent = "/home/sprite/.wisp/worktrees/\(repoName)"
         let worktreeDir = "\(worktreeParent)/\(uniqueBranchName)"
 
-        let qWorkDir = Self.shellEscapePath(currentWorkDir)
-        let qWorktreeParent = Self.shellEscapePath(worktreeParent)
-        let qWorktreeDir = Self.shellEscapePath(worktreeDir)
-        let qBranch = Self.shellEscapePath(uniqueBranchName)
-
-        // Mark all directories as safe to avoid "dubious ownership" errors when the repo
-        // is owned by a different uid than the running process (common on Sprites).
-        // Fetch origin so the new branch starts from the latest remote state (failure is non-fatal).
-        // Resolve the remote's default branch via origin/HEAD (handles master, develop, etc.);
-        // `remote set-head --auto` populates it if it's not already set. Fall back to local HEAD
-        // if everything fails (no remote, offline and never fetched) — matches pre-PR behavior.
-        // Prune stale worktree registrations (handles dirs deleted without `git worktree remove`).
-        // Capture stderr from worktree add collapsed to one line so we can log it on failure.
-        let command = """
-        git config --global --add safe.directory '*' 2>/dev/null; \
-        git -C \(qWorkDir) fetch origin 2>/dev/null || true; \
-        git -C \(qWorkDir) remote set-head origin --auto 2>/dev/null || true; \
-        BASE_REF=$(git -C \(qWorkDir) symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo HEAD); \
-        git -C \(qWorkDir) worktree prune 2>/dev/null; \
-        mkdir -p \(qWorktreeParent) && GTWT_OUT=$(git -C \(qWorkDir) worktree add \(qWorktreeDir) -b \(qBranch) "$BASE_REF" 2>&1); \
-        if [ $? -eq 0 ]; then echo \(qWorktreeDir); else echo "WORKTREE_ERR:$(echo $GTWT_OUT)"; fi
-        """
+        let command = Self.buildWorktreeSetupCommand(
+            currentWorkDir: currentWorkDir,
+            worktreeParent: worktreeParent,
+            worktreeDir: worktreeDir,
+            uniqueBranchName: uniqueBranchName
+        )
 
         let (output, _) = await apiClient.runExec(spriteName: spriteName, command: command, timeout: 60)
         // git worktree add may print "HEAD is now at..." to stdout before our echo,

--- a/WispTests/WorktreeTests.swift
+++ b/WispTests/WorktreeTests.swift
@@ -92,4 +92,64 @@ struct WorktreeTests {
         #expect(result[0].path == alreadyInWorktree.path)
         #expect(result[1].path == needsCopying.path)
     }
+
+    // MARK: - buildWorktreeSetupCommand
+
+    private func makeSetupCommand(
+        workDir: String = "/home/sprite/project",
+        parent: String = "/home/sprite/.wisp/worktrees/project",
+        dir: String = "/home/sprite/.wisp/worktrees/project/add-dark-mode-abc12345",
+        branch: String = "add-dark-mode-abc12345"
+    ) -> String {
+        ChatViewModel.buildWorktreeSetupCommand(
+            currentWorkDir: workDir,
+            worktreeParent: parent,
+            worktreeDir: dir,
+            uniqueBranchName: branch
+        )
+    }
+
+    @Test func setupCommand_fetchesOriginNonFatally() {
+        let cmd = makeSetupCommand()
+        #expect(cmd.contains("fetch origin 2>/dev/null || true"))
+    }
+
+    @Test func setupCommand_resolvesDefaultBranchViaOriginHEAD() {
+        // Regression guard: previously hardcoded `origin/main`, which broke repos with
+        // default branch master/develop/etc. Must now resolve via origin/HEAD.
+        let cmd = makeSetupCommand()
+        #expect(cmd.contains("remote set-head origin --auto"))
+        #expect(cmd.contains("symbolic-ref --short refs/remotes/origin/HEAD"))
+        #expect(cmd.contains("|| echo HEAD"))
+        #expect(cmd.contains("\"$BASE_REF\""))
+        // Must NOT hardcode origin/main as the worktree start point
+        #expect(!cmd.contains("-b 'add-dark-mode-abc12345' origin/main"))
+    }
+
+    @Test func setupCommand_usesShellEscapeForAllPaths() {
+        let cmd = makeSetupCommand(
+            workDir: "/home/sprite/my project",
+            parent: "/home/sprite/.wisp/worktrees/my project",
+            dir: "/home/sprite/.wisp/worktrees/my project/feature-abc12345",
+            branch: "feature-abc12345"
+        )
+        // Single-quoted paths with embedded spaces survive intact
+        #expect(cmd.contains("'/home/sprite/my project'"))
+        #expect(cmd.contains("'/home/sprite/.wisp/worktrees/my project/feature-abc12345'"))
+        #expect(cmd.contains("'feature-abc12345'"))
+    }
+
+    @Test func setupCommand_escapesSingleQuotesInPaths() {
+        // A path containing a single quote must be escaped via the '\'' idiom or it would
+        // break out of the surrounding shell quoting.
+        let cmd = makeSetupCommand(workDir: "/home/sprite/it's-a-repo")
+        #expect(cmd.contains("'/home/sprite/it'\\''s-a-repo'"))
+        // And the raw unescaped form must not appear
+        #expect(!cmd.contains("'/home/sprite/it's-a-repo'"))
+    }
+
+    @Test func setupCommand_echoesWorktreeDirOnSuccess() {
+        let cmd = makeSetupCommand(dir: "/home/sprite/.wisp/worktrees/project/feature-abc12345")
+        #expect(cmd.contains("echo '/home/sprite/.wisp/worktrees/project/feature-abc12345'"))
+    }
 }


### PR DESCRIPTION
## Summary

- Replaces `git pull` with `git fetch origin` when setting up a worktree for a new chat
- Branches the new worktree from `origin/main` directly instead of local HEAD
- This ensures new branches always start from the latest remote state, even if the local `main` is stale

## Test plan

- [ ] Start a new chat on a Sprite with a linked git repo — confirm worktree is created successfully
- [ ] Verify the new branch is based on the latest commit from `origin/main`
- [ ] Test with no network (fetch fails silently) — confirm worktree creation still proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)