### PR TITLE
Clear unread indicator when explicitly selecting a chat

### DIFF
--- a/Wisp/Views/SpriteDetail/Chat/ChatSwitcherSheet.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatSwitcherSheet.swift
@@ -21,6 +21,10 @@ struct ChatSwitcherSheet: View {
                     )
                     .contentShape(Rectangle())
                     .onTapGesture {
+                        if chat.isUnread {
+                            chat.isUnread = false
+                            try? modelContext.save()
+                        }
                         viewModel.selectChat(chat)
                         dismiss()
                     }

--- a/Wisp/Views/SpriteDetail/SpriteDetailView.swift
+++ b/Wisp/Views/SpriteDetail/SpriteDetailView.swift
@@ -48,6 +48,7 @@ struct SpriteDetailView: View {
                 case .chat(let id):
                     selectedTab = .chat
                     if let chat = chatListViewModel.chats.first(where: { $0.id == id }) {
+                        markChatRead(chat)
                         switchToChat(chat)
                     }
                 }
@@ -87,6 +88,7 @@ struct SpriteDetailView: View {
             sprite: sprite,
             chatListViewModel: chatListViewModel,
             onChatSelected: { chat in
+                markChatRead(chat)
                 switchToChat(chat)
                 showingChat = true
             },
@@ -343,17 +345,22 @@ struct SpriteDetailView: View {
         )
     }
 
+    /// Called by user-tap sites (overview row, iPad nav panel, switcher sheet via
+    /// `selectChat`) to clear the unread indicator. Kept separate from `switchToChat`
+    /// because that method is also called programmatically (e.g. from the initial
+    /// `.task` that positions on the last-active chat), where clearing unread would
+    /// be wrong — the user never explicitly selected anything.
+    private func markChatRead(_ chat: SpriteChat) {
+        guard chat.isUnread else { return }
+        chat.isUnread = false
+        try? modelContext.save()
+    }
+
     private func switchToChat(_ chat: SpriteChat) {
         guard chatViewModel?.chatId != chat.id else { return }
 
         // Deactivate outgoing VM
         chatViewModel?.isActive = false
-
-        // Clear unread when opening a chat
-        if chat.isUnread {
-            chat.isUnread = false
-            try? modelContext.save()
-        }
 
         // Look up or create a VM from the app-wide cache — old VM keeps streaming in background
         let vm = chatSessionManager.viewModel(


### PR DESCRIPTION
## Summary

Fixes a bug where tapping a chat with an unread indicator didn't clear the indicator if the user had just been viewing that same chat.

### Root cause

`SpriteDetailView.switchToChat` early-returns via `guard chatViewModel?.chatId != chat.id` before reaching any unread-clearing code. On iPhone this trips often:

1. Overview → tap chat A → \`chatViewModel\` is set, \`isActive = true\`
2. Pop back to overview → ChatView's \`.onDisappear\` sets \`isActive = false\`, but \`chatViewModel\` still references A
3. New event arrives → \`markChatUnread\` passes its \`!isActive\` guard → chat A marked unread
4. User taps chat A → \`switchToChat(A)\` → early-return guard fires → **unread never cleared**

### Why the first attempt was wrong

Moving the unread clear *above* the guard inside \`switchToChat\` fixed the retap case, but introduced a new bug: the initial \`.task\` at view appearance calls \`switchToChat(active)\` to position on the last-viewed chat, and \`onChange(of: activeChatId)\` also fires from programmatic paths like \`loadChats\`. Both would now clear unread without the user ever explicitly selecting the chat.

### Fix

Keep \`switchToChat\` untouched. Add a \`markChatRead\` helper and call it only at the three **user-driven** tap sites:

- \`navSelectionBinding\` case \`.chat\` (iPad nav panel)
- \`onChatSelected\` in the compact overview layout (iPhone)
- \`onTapGesture\` in \`ChatSwitcherSheet\`

Programmatic callers (\`.task\` init, \`loadChats\`-triggered \`onChange\`) never touch unread state.

## Test plan

- [ ] Open a sprite whose last-active chat has an unread indicator — indicator should remain after the overview appears
- [ ] Tap chat A, pop back to overview, wait for a new event on A, re-tap A — indicator should clear
- [ ] Same flow via the chat switcher sheet
- [ ] iPad: same flow via the sidebar nav panel
- [ ] Regression: switching from chat A to chat B still clears B's unread

🤖 Generated with [Claude Code](https://claude.com/claude-code)