### PR TITLE
Fix chat switcher sheet selection not swapping chat content

### DIFF
--- a/Wisp/Views/SpriteDetail/Chat/ChatSwitcherSheet.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatSwitcherSheet.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 struct ChatSwitcherSheet: View {
     @Bindable var viewModel: SpriteChatListViewModel
+    var onSelectChat: ((SpriteChat) -> Void)? = nil
     @Environment(SpritesAPIClient.self) private var apiClient
     @Environment(ChatSessionManager.self) private var chatSessionManager
     @Environment(\.modelContext) private var modelContext
@@ -25,7 +26,16 @@ struct ChatSwitcherSheet: View {
                             chat.isUnread = false
                             try? modelContext.save()
                         }
-                        viewModel.selectChat(chat)
+                        // Route selection via an explicit callback rather than mutating
+                        // activeChatId here. The sheet runs inside a pushed ChatView subtree,
+                        // and SpriteDetailView's onChange(of: activeChatId) doesn't fire in
+                        // that context unless the property is already observed in its body —
+                        // so relying on observation would silently drop the selection.
+                        if let onSelectChat {
+                            onSelectChat(chat)
+                        } else {
+                            viewModel.selectChat(chat)
+                        }
                         dismiss()
                     }
                     .contextMenu {

--- a/Wisp/Views/SpriteDetail/Chat/ChatView.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatView.swift
@@ -12,6 +12,7 @@ struct ChatView: View {
     var topAccessory: AnyView? = nil
     var chatListViewModel: SpriteChatListViewModel? = nil
     var onNewChat: (() -> Void)? = nil
+    var onSelectChat: ((SpriteChat) -> Void)? = nil
     var existingSessionIds: Set<String> = []
     var onFork: ((String, UUID) -> Void)? = nil
     @FocusState private var isInputFocused: Bool
@@ -230,7 +231,7 @@ struct ChatView: View {
         }
         .sheet(isPresented: $showChatSwitcher) {
             if let chatListVM = chatListViewModel {
-                ChatSwitcherSheet(viewModel: chatListVM)
+                ChatSwitcherSheet(viewModel: chatListVM, onSelectChat: onSelectChat)
             }
         }
         .sheet(item: $quickActionsViewModel) { vm in

--- a/Wisp/Views/SpriteDetail/SpriteDetailView.swift
+++ b/Wisp/Views/SpriteDetail/SpriteDetailView.swift
@@ -152,6 +152,10 @@ struct SpriteDetailView: View {
                         let chat = chatListViewModel.createChat(modelContext: modelContext)
                         switchToChat(chat)
                     },
+                    onSelectChat: { chat in
+                        markChatRead(chat)
+                        switchToChat(chat)
+                    },
                     existingSessionIds: Set(chatListViewModel.chats.filter { !$0.isClosed }.compactMap(\.claudeSessionId)),
                     onFork: { checkpointId, messageId in
                         pendingFork = (checkpointId, messageId)


### PR DESCRIPTION
## Summary

Selecting a chat from the chat switcher sheet did nothing visually — the switcher row highlighted the new chat but ChatView kept showing the old chat's content. Root cause was a subtle `@Observable` + `onChange` gotcha.

### Root cause

The sheet was mutating `chatListViewModel.activeChatId` via `selectChat` and relying on `SpriteDetailView`'s `.onChange(of: chatListViewModel.activeChatId)` observer to fire `switchToChat`.

But `activeChatId` was only ever read inside the `onChange` modifier itself — never anywhere else in `SpriteDetailView`'s body. SwiftUI's Observation framework requires a body-level dependency on an `@Observable` property to wake the view up when the property changes. Without that dependency, the Observation framework never re-evaluates `SpriteDetailView`'s body in response to the mutation, and `onChange`'s "previous value → current value" diff never catches the change. The closure silently never fires.

Confirmed via instrumentation — on a switcher sheet tap, `selectChat` successfully set the new id on the view model, but `onChange` never ran and `switchToChat` was never called, so `chatViewModel` stayed bound to the old chat.

(The iPad sidebar path and the iPhone "tap from overview" path worked because they call `switchToChat` directly in-place, rather than going via `activeChatId` observation.)

### Fix

Route the switcher sheet's selection via an explicit callback instead of relying on observation through a sheet/navigation-stack boundary:

- Add `onSelectChat: ((SpriteChat) -> Void)?` to `ChatView`
- Add matching callback to `ChatSwitcherSheet`
- Wire it up in `SpriteDetailView`'s `navigationDestination` to call `markChatRead(chat); switchToChat(chat)` directly

The existing `onChange(of: activeChatId)` observer still exists as a fallback for any future path that mutates `activeChatId` from the parent's subtree (where the observation does fire).

## Test plan

- [ ] Open chat A from the overview
- [ ] Open the chat switcher sheet from the chat toolbar
- [ ] Tap chat B — verify chat B's content appears
- [ ] Tap switcher again, tap chat C — verify chat C's content appears
- [ ] Regression: iPad sidebar chat selection still works
- [ ] Regression: iPhone overview tap-to-open still works
- [ ] Regression: unread indicators are still cleared on selection (both from overview and switcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)