### PR TITLE
Replace Claude JSONL session restore with wisp stream log files

### DIFF
--- a/Wisp/Models/Claude/ClaudeEventTypes.swift
+++ b/Wisp/Models/Claude/ClaudeEventTypes.swift
@@ -127,3 +127,20 @@ struct ClaudeResultEvent: Codable, Sendable {
         case numTurns = "num_turns"
     }
 }
+
+// MARK: - Wisp User Prompt Event
+
+/// Custom event written to the wisp NDJSON log file before each Claude invocation.
+/// User prompts don't appear in Claude's stream-json output (they're CLI arguments),
+/// so we write them ourselves to make the log file self-contained.
+struct WispUserPromptEvent: Codable, Sendable {
+    let type: String
+    let text: String
+    let timestamp: String
+
+    init(text: String, timestamp: String) {
+        self.type = "wisp_user_prompt"
+        self.text = text
+        self.timestamp = timestamp
+    }
+}

--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -345,11 +345,11 @@ final class ChatViewModel {
 
         let encodedPath = Self.claudeProjectPathEncoding(workingDirectory)
         let projectDir = "/home/sprite/.claude/projects/\(encodedPath)"
-        let command = "cat '\(projectDir)/\(sessionId).jsonl' 2>/dev/null"
+        let jsonlPath = "\(projectDir)/\(sessionId).jsonl"
 
         let (output, _) = await apiClient.runExec(
             spriteName: spriteName,
-            command: command,
+            command: "cat '\(jsonlPath)' 2>/dev/null",
             timeout: 15
         )
 
@@ -363,16 +363,40 @@ final class ChatViewModel {
         rebuildToolUseIndex()
         persistMessages(modelContext: modelContext)
 
-        // Convert JSONL to wisp format and write to sprite so future loads use one code path
-        let wispContent = Self.convertJSONLToWisp(output)
-        if !wispContent.isEmpty {
-            let logPath = Self.wispLogPath(for: chatId)
-            _ = await apiClient.runExec(
-                spriteName: spriteName,
-                command: "mkdir -p /home/sprite/.wisp/chats && cat > \(shellEscape(logPath)) <<'WISP_EOF'\n\(wispContent)\nWISP_EOF",
-                timeout: 15
-            )
-        }
+        // Convert JSONL to wisp format on the sprite so future loads use one code path.
+        // Done entirely on-sprite with jq to avoid transferring large data via URL params.
+        let logPath = Self.wispLogPath(for: chatId)
+        _ = await apiClient.runExec(
+            spriteName: spriteName,
+            command: Self.jsonlToWispCommand(jsonlPath: jsonlPath, wispLogPath: logPath),
+            timeout: 15
+        )
+    }
+
+    /// Build a shell command that converts a Claude JSONL file to wisp format on the sprite.
+    /// User prompts become wisp_user_prompt events; assistant/system/result lines pass through;
+    /// CLI-injected entries (bash-input, bash-stdout, local-command-caveat) and meta entries are skipped.
+    nonisolated static func jsonlToWispCommand(jsonlPath: String, wispLogPath: String) -> String {
+        // jq processes each line independently (-c for compact output).
+        // User prompts with string content → wisp_user_prompt events.
+        // Tool result user entries and assistant/system/result → pass through verbatim.
+        // Everything else (attachment, file-history-snapshot, permission-mode, etc.) → skipped.
+        """
+        mkdir -p /home/sprite/.wisp/chats && jq -c '
+          if .type == "user" then
+            if .isMeta then empty
+            elif (.message.content | type) == "string" then
+              if (.message.content | test("^<(local-command-caveat|bash-input|bash-stdout)")) then empty
+              else {type: "wisp_user_prompt", text: .message.content, timestamp: (.timestamp // "")}
+              end
+            elif (.message.content | type) == "array" and (.message.content | any(.type == "tool_result")) then .
+            else empty
+            end
+          elif .type == "assistant" or .type == "system" or .type == "result" then .
+          else empty
+          end
+        ' \(shellEscape(jsonlPath)) > \(shellEscape(wispLogPath))
+        """
     }
 
 
@@ -609,7 +633,6 @@ final class ChatViewModel {
     /// formats share the same structure — extra JSONL fields are ignored by the decoder).
     static func convertJSONLToWisp(_ jsonl: String) -> String {
         let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
         let encoder = JSONEncoder()
 
         var lines: [String] = []

--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -333,12 +333,13 @@ final class ChatViewModel {
         saveSession(modelContext: modelContext)
 
         Task {
-            await loadRemoteHistory(apiClient: apiClient, modelContext: modelContext)
+            await importJSONLSession(sessionId: entry.sessionId, apiClient: apiClient, modelContext: modelContext)
         }
     }
 
-    private func loadRemoteHistory(apiClient: SpritesAPIClient, modelContext: ModelContext) async {
-        guard let sessionId else { return }
+    /// Import a Claude JSONL session: read the JSONL, convert to wisp format, write the
+    /// wisp file to the sprite, then load via the normal wisp log path.
+    private func importJSONLSession(sessionId: String, apiClient: SpritesAPIClient, modelContext: ModelContext) async {
         isLoadingHistory = true
         defer { isLoadingHistory = false }
 
@@ -354,13 +355,27 @@ final class ChatViewModel {
 
         guard !output.isEmpty else { return }
 
+        // Parse JSONL for immediate display
         let parsed = Self.parseSessionJSONL(output)
         guard !parsed.isEmpty else { return }
 
         messages = parsed
         rebuildToolUseIndex()
         persistMessages(modelContext: modelContext)
+
+        // Convert JSONL to wisp format and write to sprite so future loads use one code path
+        let wispContent = Self.convertJSONLToWisp(output)
+        if !wispContent.isEmpty {
+            let logPath = Self.wispLogPath(for: chatId)
+            _ = await apiClient.runExec(
+                spriteName: spriteName,
+                command: "mkdir -p /home/sprite/.wisp/chats && cat > \(shellEscape(logPath)) <<'WISP_EOF'\n\(wispContent)\nWISP_EOF",
+                timeout: 15
+            )
+        }
     }
+
+
 
     /// Parse a Claude session JSONL string into ChatMessages.
     /// Resilient — skips any lines that fail to decode.
@@ -483,6 +498,179 @@ final class ChatViewModel {
         }
 
         return messages
+    }
+
+    /// Parse a wisp NDJSON log file into ChatMessages.
+    /// The file contains `wisp_user_prompt` events (user messages) interleaved with
+    /// raw Claude stream-json events (system, assistant, user/tool_result, result).
+    /// Resilient — skips any lines that fail to decode.
+    static func parseWispLog(_ ndjson: String) -> (messages: [ChatMessage], sessionId: String?) {
+        var messages: [ChatMessage] = []
+        var currentAssistant: ChatMessage?
+        var toolUseCards: [String: ToolUseCard] = [:]
+        var sessionId: String?
+        let decoder = JSONDecoder.apiDecoder()
+
+        for line in ndjson.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let data = line.data(using: .utf8) else { continue }
+
+            // Try wisp user prompt event first
+            if let wispEvent = try? decoder.decode(WispUserPromptEvent.self, from: Data(data)),
+               wispEvent.type == "wisp_user_prompt" {
+                if let assistant = currentAssistant {
+                    messages.append(assistant)
+                    currentAssistant = nil
+                }
+                messages.append(ChatMessage(role: .user, content: [.text(wispEvent.text)]))
+                continue
+            }
+
+            // Try Claude stream event
+            guard let event = try? decoder.decode(ClaudeStreamEvent.self, from: Data(data)) else {
+                continue
+            }
+
+            switch event {
+            case .system(let se):
+                sessionId = se.sessionId
+
+            case .assistant(let ae):
+                let assistant = currentAssistant ?? ChatMessage(role: .assistant)
+                if currentAssistant == nil { currentAssistant = assistant }
+
+                for block in ae.message.content {
+                    switch block {
+                    case .text(let text):
+                        guard !text.isEmpty else { continue }
+                        if case .text(let existing) = assistant.content.last {
+                            assistant.content[assistant.content.count - 1] = .text(existing + text)
+                        } else {
+                            assistant.content.append(.text(text))
+                        }
+                    case .toolUse(let toolUse):
+                        let card = ToolUseCard(
+                            toolUseId: toolUse.id,
+                            toolName: toolUse.name,
+                            input: toolUse.input
+                        )
+                        toolUseCards[toolUse.id] = card
+                        assistant.content.append(.toolUse(card))
+                    case .unknown:
+                        break
+                    }
+                }
+
+            case .user(let toolResultEvent):
+                let assistant = currentAssistant ?? ChatMessage(role: .assistant)
+                if currentAssistant == nil { currentAssistant = assistant }
+
+                for result in toolResultEvent.message.content {
+                    let toolName = toolUseCards[result.toolUseId]?.toolName ?? "Tool"
+                    let resultCard = ToolResultCard(
+                        toolUseId: result.toolUseId,
+                        toolName: toolName,
+                        content: result.content ?? .null
+                    )
+                    toolUseCards[result.toolUseId]?.result = resultCard
+                    assistant.content.append(.toolResult(resultCard))
+                }
+
+            case .result(let re):
+                sessionId = re.sessionId
+                if let assistant = currentAssistant {
+                    messages.append(assistant)
+                    currentAssistant = nil
+                }
+
+            case .unknown:
+                break
+            }
+        }
+
+        // Finalize any trailing assistant message
+        if let assistant = currentAssistant {
+            messages.append(assistant)
+        }
+
+        return (messages, sessionId)
+    }
+
+    /// Convert a Claude JSONL session string to wisp NDJSON format.
+    /// User prompts become `wisp_user_prompt` events; assistant, tool result,
+    /// system, and result lines are passed through verbatim (the JSONL and stream
+    /// formats share the same structure — extra JSONL fields are ignored by the decoder).
+    static func convertJSONLToWisp(_ jsonl: String) -> String {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let encoder = JSONEncoder()
+
+        var lines: [String] = []
+
+        for line in jsonl.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let data = line.data(using: .utf8),
+                  let entry = try? decoder.decode(SessionJSONLLine.self, from: Data(data)),
+                  let type = entry.type
+            else { continue }
+
+            if type == "user" {
+                guard entry.isMeta != true else { continue }
+
+                if let content = entry.message?.content {
+                    switch content {
+                    case .string(let text):
+                        // User prompt — convert to wisp_user_prompt
+                        let event = WispUserPromptEvent(text: text, timestamp: "")
+                        if let eventData = try? encoder.encode(event),
+                           let eventStr = String(data: eventData, encoding: .utf8) {
+                            lines.append(eventStr)
+                        }
+                    case .blocks(let blocks):
+                        let hasToolResults = blocks.contains { $0.type == "tool_result" }
+                        if hasToolResults {
+                            // Tool results — pass through verbatim
+                            lines.append(String(line))
+                        } else {
+                            // Text-only blocks — convert to wisp_user_prompt
+                            let text = blocks.compactMap { $0.text }.joined(separator: "\n")
+                            guard !text.isEmpty else { continue }
+                            let event = WispUserPromptEvent(text: text, timestamp: "")
+                            if let eventData = try? encoder.encode(event),
+                               let eventStr = String(data: eventData, encoding: .utf8) {
+                                lines.append(eventStr)
+                            }
+                        }
+                    }
+                }
+            } else {
+                // system, assistant, result — pass through verbatim
+                lines.append(String(line))
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    /// Load chat history from the wisp NDJSON log file on the sprite.
+    private func loadFromWispLog(apiClient: SpritesAPIClient, modelContext: ModelContext) async {
+        isLoadingHistory = true
+        defer { isLoadingHistory = false }
+
+        let logPath = Self.wispLogPath(for: chatId)
+        let (output, success) = await apiClient.runExec(
+            spriteName: spriteName,
+            command: "cat \(shellEscape(logPath)) 2>/dev/null",
+            timeout: 30
+        )
+
+        guard success, !output.isEmpty else { return }
+
+        let (parsed, parsedSessionId) = Self.parseWispLog(output)
+        guard !parsed.isEmpty else { return }
+
+        messages = parsed
+        if let parsedSessionId { sessionId = parsedSessionId }
+        rebuildToolUseIndex()
+        persistMessages(modelContext: modelContext)
     }
 
     func persistMessages(modelContext: ModelContext) {
@@ -687,12 +875,11 @@ final class ChatViewModel {
         guard !isStreaming else { return }
 
         if messages.isEmpty {
-            // No local messages but we know the session ID — the JSONL file on the
-            // sprite contains the full conversation. Load it so the chat isn't blank.
-            // This handles the case where SwiftData was cleared, the app was reinstalled,
-            // or the path-encoding bug previously caused loadRemoteHistory to silently fail.
-            if sessionId != nil, !isLoadingHistory {
-                Task { await loadRemoteHistory(apiClient: apiClient, modelContext: modelContext) }
+            // No local messages — the wisp log file (or legacy JSONL) on the sprite
+            // contains the full conversation. Load it so the chat isn't blank.
+            // This handles the case where SwiftData was cleared or the app was reinstalled.
+            if !isLoadingHistory {
+                Task { await loadFromWispLog(apiClient: apiClient, modelContext: modelContext) }
             }
             return
         }
@@ -782,12 +969,26 @@ final class ChatViewModel {
         }
 
         // Build the full bash -c command with env vars inlined
+        let logPath = Self.wispLogPath(for: chatId)
         var commandParts: [String] = [
             "export CLAUDE_CODE_OAUTH_TOKEN=\(shellEscape(claudeToken))",
             "export NO_DNA=1", // Signal to CLIs that they're running under an agent operator (no-dna.org)
             "mkdir -p \(shellEscape(workingDirectory))",
+            "mkdir -p /home/sprite/.wisp/chats",
             "cd \(shellEscape(workingDirectory))",
         ]
+
+        // Write the user prompt to the wisp log file before launching Claude.
+        // Stream output doesn't include user prompts (they're CLI arguments),
+        // so we write them ourselves to make the log file self-contained.
+        let promptEvent = WispUserPromptEvent(
+            text: prompt,
+            timestamp: ISO8601DateFormatter().string(from: Date())
+        )
+        if let jsonData = try? JSONEncoder().encode(promptEvent),
+           let jsonStr = String(data: jsonData, encoding: .utf8) {
+            commandParts.append("printf '%s\\n' \(shellEscape(jsonStr)) >> \(shellEscape(logPath))")
+        }
 
         let gitName = UserDefaults.standard.string(forKey: "gitName") ?? ""
         let gitEmail = UserDefaults.standard.string(forKey: "gitEmail") ?? ""
@@ -831,7 +1032,7 @@ final class ChatViewModel {
         // is waiting for an API response and Wisp is detached. The heartbeat
         // writes a byte to stderr every 20s — enough to count as output without
         // interfering with the NDJSON stdout stream. The trap ensures cleanup.
-        let wrappedClaudeCmd = "{ (while true; do sleep 20; printf . >&2; done) & HBEAT=$!; trap \"kill $HBEAT 2>/dev/null\" EXIT; \(claudeCmd); kill $HBEAT 2>/dev/null; }"
+        let wrappedClaudeCmd = "{ (while true; do sleep 20; printf . >&2; done) & HBEAT=$!; trap \"kill $HBEAT 2>/dev/null\" EXIT; \(claudeCmd) | tee -a \(shellEscape(logPath)); kill $HBEAT 2>/dev/null; }"
         commandParts.append(wrappedClaudeCmd)
         let fullCommand = commandParts.joined(separator: " && ")
 
@@ -1170,6 +1371,32 @@ final class ChatViewModel {
     /// Restore chat history from Claude's .jsonl session file on the sprite.
     /// Used when the exec session is gone (sprite slept, exec expired).
     private func restoreFromSessionFile(apiClient: SpritesAPIClient, modelContext: ModelContext) async {
+        // Try wisp log file first — it captures the full stream including sub-agent calls.
+        let logPath = Self.wispLogPath(for: chatId)
+        let (wispOutput, wispSuccess) = await apiClient.runExec(
+            spriteName: spriteName,
+            command: "cat \(shellEscape(logPath)) 2>/dev/null",
+            timeout: 30
+        )
+
+        if wispSuccess, !wispOutput.isEmpty {
+            let (parsed, parsedSessionId) = Self.parseWispLog(wispOutput)
+            if !parsed.isEmpty {
+                messages = parsed
+                if let parsedSessionId { sessionId = parsedSessionId }
+                rebuildToolUseIndex()
+
+                if let last = messages.last, last.role == .user {
+                    restoreUndeliveredDraft(modelContext: modelContext)
+                } else {
+                    self.execSessionId = nil
+                    saveSession(modelContext: modelContext, isComplete: true)
+                }
+                return
+            }
+        }
+
+        // Fallback: read Claude's internal JSONL for chats that predate wisp log files.
         guard let sessionId = sessionId else { return }
 
         let encodedPath = Self.claudeProjectPathEncoding(workingDirectory)
@@ -1182,7 +1409,6 @@ final class ChatViewModel {
         )
 
         if !success || output.isEmpty {
-            // Fallback: search for the file
             let (findOutput, _) = await apiClient.runExec(
                 spriteName: spriteName,
                 command: "find ~/.claude -name '\(sessionId).jsonl' -print -quit 2>/dev/null",
@@ -1203,59 +1429,15 @@ final class ChatViewModel {
         let parsed = Self.parseSessionJSONL(output)
         guard !parsed.isEmpty else { return }
 
-        // Merge with locally-persisted messages to preserve sub-agent tool calls.
-        // The main JSONL only contains the main agent's turns; sub-agent tool calls
-        // (Bash, Read, Write, etc.) are streamed live and persisted locally but stored
-        // in separate session files on the sprite. Use local messages as the base and
-        // patch the final assistant text from the JSONL if it is more complete.
-        messages = mergedWithLocalMessages(parsed)
+        messages = parsed
         rebuildToolUseIndex()
 
         if let last = messages.last, last.role == .user {
-            // Trailing user message — restore as draft
             restoreUndeliveredDraft(modelContext: modelContext)
         } else {
             self.execSessionId = nil
             saveSession(modelContext: modelContext, isComplete: true)
         }
-    }
-
-    /// Merge JSONL-parsed messages with the current locally-persisted messages.
-    /// Returns the local messages enriched with any more-complete text from the JSONL,
-    /// or falls back to the JSONL messages if the conversation structures differ.
-    func mergedWithLocalMessages(_ jsonlMessages: [ChatMessage]) -> [ChatMessage] {
-        guard !messages.isEmpty else { return jsonlMessages }
-
-        let localUserCount = messages.filter { $0.role == .user }.count
-        let jsonlUserCount = jsonlMessages.filter { $0.role == .user }.count
-        guard localUserCount == jsonlUserCount else { return jsonlMessages }
-
-        // If the JSONL's total text is longer (more complete) than the locally-persisted
-        // version, patch only the final text block in place. Using total text for the
-        // comparison detects truncation; patching only the last block preserves any intro
-        // text that appeared before tool calls (e.g. "Let me check…" → tools → "Done!").
-        if let jsonlLast = jsonlMessages.last(where: { $0.role == .assistant }),
-           let localLast = messages.last(where: { $0.role == .assistant }),
-           jsonlLast.textContent.count > localLast.textContent.count {
-            // Find the last text segment in the JSONL message to use as the replacement.
-            var jsonlFinalText: String?
-            for item in jsonlLast.content.reversed() {
-                if case .text(let t) = item, !t.isEmpty { jsonlFinalText = t; break }
-            }
-            if let finalText = jsonlFinalText {
-                if let idx = localLast.content.indices.reversed().first(where: {
-                    if case .text = localLast.content[$0] { return true } else { return false }
-                }) {
-                    localLast.content[idx] = .text(finalText)
-                } else {
-                    // No trailing text block yet — Claude was still running tools when we
-                    // disconnected. Append the final response from the JSONL.
-                    localLast.content.append(.text(finalText))
-                }
-            }
-        }
-
-        return messages
     }
 
     func handleEvent(_ event: ClaudeStreamEvent, modelContext: ModelContext) {
@@ -1762,6 +1944,11 @@ final class ChatViewModel {
     ///
     /// Wisp previously only replaced `/`, producing `-home-sprite-.wisp-...`
     /// which didn't match the on-disk directory name.
+    /// Path to the wisp stream log file for a given chat on the sprite.
+    nonisolated static func wispLogPath(for chatId: UUID) -> String {
+        "/home/sprite/.wisp/chats/\(chatId.uuidString.lowercased()).wisplog"
+    }
+
     nonisolated static func claudeProjectPathEncoding(_ path: String) -> String {
         path
             .replacingOccurrences(of: "/", with: "-")

--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -618,6 +618,12 @@ final class ChatViewModel {
                 if let content = entry.message?.content {
                     switch content {
                     case .string(let text):
+                        // Skip CLI-injected entries (local commands run via `!`)
+                        if text.hasPrefix("<local-command-caveat>")
+                            || text.hasPrefix("<bash-input>")
+                            || text.hasPrefix("<bash-stdout>") {
+                            continue
+                        }
                         // User prompt — convert to wisp_user_prompt
                         let event = WispUserPromptEvent(text: text, timestamp: "")
                         if let eventData = try? encoder.encode(event),
@@ -633,6 +639,12 @@ final class ChatViewModel {
                             // Text-only blocks — convert to wisp_user_prompt
                             let text = blocks.compactMap { $0.text }.joined(separator: "\n")
                             guard !text.isEmpty else { continue }
+                            // Skip CLI-injected entries in block form too
+                            if text.hasPrefix("<local-command-caveat>")
+                                || text.hasPrefix("<bash-input>")
+                                || text.hasPrefix("<bash-stdout>") {
+                                continue
+                            }
                             let event = WispUserPromptEvent(text: text, timestamp: "")
                             if let eventData = try? encoder.encode(event),
                                let eventStr = String(data: eventData, encoding: .utf8) {
@@ -641,8 +653,9 @@ final class ChatViewModel {
                         }
                     }
                 }
-            } else {
-                // system, assistant, result — pass through verbatim
+            } else if type == "system" || type == "assistant" || type == "result" {
+                // Pass through verbatim — skip non-conversation types
+                // (file-history-snapshot, last-prompt, permission-mode, etc.)
                 lines.append(String(line))
             }
         }

--- a/Wisp/ViewModels/ChatViewModel.swift
+++ b/Wisp/ViewModels/ChatViewModel.swift
@@ -393,9 +393,16 @@ final class ChatViewModel {
 
             switch type {
             case "user":
+                guard entry.isMeta != true else { continue }
                 guard let content = entry.message?.content else { continue }
                 switch content {
                 case .string(let text):
+                    // Skip CLI-injected entries (local commands run via `!`)
+                    if text.hasPrefix("<local-command-caveat>")
+                        || text.hasPrefix("<bash-input>")
+                        || text.hasPrefix("<bash-stdout>") {
+                        continue
+                    }
                     // User prompt — finalize any current assistant message
                     if let assistant = currentAssistant {
                         messages.append(assistant)
@@ -409,19 +416,20 @@ final class ChatViewModel {
                     let toolResultBlocks = blocks.filter { $0.type == "tool_result" }
 
                     if !textBlocks.isEmpty && toolResultBlocks.isEmpty {
-                        // Pure text blocks: either a real user message (non-meta) or an
-                        // internal injection like a skill invocation (isMeta:true).
-                        // Skip meta entries — they're not user-authored content.
-                        if entry.isMeta == true { break }
-
                         // Non-meta user message stored as text blocks (some Claude Code
                         // versions write user turns as [{type:text,text:...}] instead of
                         // a plain string). Treat it the same as the string case.
+                        let text = textBlocks.compactMap { $0.text }.joined(separator: "\n")
+                        // Skip CLI-injected entries in block form too
+                        if text.hasPrefix("<local-command-caveat>")
+                            || text.hasPrefix("<bash-input>")
+                            || text.hasPrefix("<bash-stdout>") {
+                            continue
+                        }
                         if let assistant = currentAssistant {
                             messages.append(assistant)
                             currentAssistant = nil
                         }
-                        let text = textBlocks.compactMap { $0.text }.joined(separator: "\n")
                         let msg = ChatMessage(role: .user, content: [.text(text)])
                         messages.append(msg)
                     } else {

--- a/Wisp/ViewModels/SpriteChatListViewModel.swift
+++ b/Wisp/ViewModels/SpriteChatListViewModel.swift
@@ -60,11 +60,13 @@ final class SpriteChatListViewModel {
         chat.isClosed = true
         try? modelContext.save()
 
-        // Remove worktree (best-effort, fire-and-forget)
+        // Remove worktree and wisp log file (best-effort, fire-and-forget)
+        let chatId = chat.id
+        let sName = spriteName
         if let path = chat.worktreePath {
-            let sName = spriteName
             Task { await Self.removeWorktree(path: path, spriteName: sName, apiClient: apiClient) }
         }
+        Task { await Self.removeWispLog(chatId: chatId, spriteName: sName, apiClient: apiClient) }
 
         // If closing the active chat, select next open chat
         if activeChatId == chat.id {
@@ -75,11 +77,13 @@ final class SpriteChatListViewModel {
     func deleteChat(_ chat: SpriteChat, apiClient: SpritesAPIClient, modelContext: ModelContext) {
         let wasActive = activeChatId == chat.id
 
-        // Remove worktree (best-effort, fire-and-forget)
+        // Remove worktree and wisp log file (best-effort, fire-and-forget)
+        let chatId = chat.id
+        let sName = spriteName
         if let path = chat.worktreePath {
-            let sName = spriteName
             Task { await Self.removeWorktree(path: path, spriteName: sName, apiClient: apiClient) }
         }
+        Task { await Self.removeWispLog(chatId: chatId, spriteName: sName, apiClient: apiClient) }
 
         chats.removeAll { $0.id == chat.id }
         modelContext.delete(chat)
@@ -110,6 +114,14 @@ final class SpriteChatListViewModel {
         try? modelContext.save()
         chats = []
         activeChatId = nil
+        // Remove all wisp log files in one shot
+        Task {
+            _ = await apiClient.runExec(
+                spriteName: sName,
+                command: "rm -rf /home/sprite/.wisp/chats",
+                timeout: 10
+            )
+        }
         logger.info("Cleared all chats for \(self.spriteName)")
     }
 
@@ -126,6 +138,15 @@ final class SpriteChatListViewModel {
             spriteName: spriteName,
             command: "git -C '\(path)' worktree remove --force '\(path)' 2>/dev/null || true",
             timeout: 15
+        )
+    }
+
+    private static func removeWispLog(chatId: UUID, spriteName: String, apiClient: SpritesAPIClient) async {
+        let logPath = ChatViewModel.wispLogPath(for: chatId)
+        _ = await apiClient.runExec(
+            spriteName: spriteName,
+            command: "rm -f '\(logPath)'",
+            timeout: 10
         )
     }
 

--- a/Wisp/Views/SpriteDetail/Chat/ChatView.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatView.swift
@@ -75,6 +75,16 @@ struct ChatView: View {
                 .opacity(contentOpacity)
                 .padding()
             }
+            .overlay {
+                if viewModel.isLoadingHistory && contentOpacity == 0 {
+                    VStack(spacing: 8) {
+                        ProgressView()
+                        Text("Loading session…")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
             .defaultScrollAnchor(.bottom)
             .scrollDismissesKeyboard(.interactively)
             .onChange(of: viewModel.messages.count) {

--- a/WispTests/ChatViewModelTests.swift
+++ b/WispTests/ChatViewModelTests.swift
@@ -1451,4 +1451,37 @@ struct ChatViewModelTests {
         #expect(lines[0].contains("system"))
         #expect(lines[1].contains("result"))
     }
+
+    @Test func convertJSONLToWisp_cliInjectedEntriesSkipped() {
+        let jsonl = """
+        {"type":"user","message":{"role":"user","content":"real prompt"},"session_id":"s1"}
+        {"type":"user","message":{"role":"user","content":"<local-command-caveat>Caveat: ...</local-command-caveat>"},"session_id":"s1"}
+        {"type":"user","message":{"role":"user","content":"<bash-input>ls</bash-input>"},"session_id":"s1"}
+        {"type":"user","message":{"role":"user","content":"<bash-stdout>file1.txt</bash-stdout><bash-stderr></bash-stderr>"},"session_id":"s1"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"response"}]},"session_id":"s1"}
+        """
+
+        let wisp = ChatViewModel.convertJSONLToWisp(jsonl)
+        let lines = wisp.split(separator: "\n")
+
+        #expect(lines.count == 2) // real prompt + assistant only
+        #expect(lines[0].contains("wisp_user_prompt"))
+        #expect(lines[0].contains("real prompt"))
+    }
+
+    @Test func convertJSONLToWisp_nonConversationTypesSkipped() {
+        let jsonl = """
+        {"type":"system","session_id":"s1","model":"claude-sonnet"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"session_id":"s1"}
+        {"type":"file-history-snapshot","messageId":"abc","snapshot":{}}
+        {"type":"last-prompt","lastPrompt":"hello","sessionId":"s1"}
+        {"type":"permission-mode","permissionMode":"bypassPermissions","sessionId":"s1"}
+        {"type":"result","session_id":"s1","is_error":false}
+        """
+
+        let wisp = ChatViewModel.convertJSONLToWisp(jsonl)
+        let lines = wisp.split(separator: "\n")
+
+        #expect(lines.count == 3) // system + assistant + result only
+    }
 }

--- a/WispTests/ChatViewModelTests.swift
+++ b/WispTests/ChatViewModelTests.swift
@@ -472,6 +472,96 @@ struct ChatViewModelTests {
         #expect(messages[0].textContent == "Hello from blocks")
     }
 
+    @Test func parseSessionJSONL_realisticMultiTurnWithThinkingAndExtras() {
+        // Mirrors the structure of a real Claude Code JSONL file:
+        // permission-mode, file-history-snapshot, attachment, system, thinking blocks,
+        // CLI-injected entries (bash-input, bash-stdout, local-command-caveat)
+        let jsonl = """
+        {"type":"permission-mode","permissionMode":"bypassPermissions","sessionId":"s1"}
+        {"type":"file-history-snapshot","messageId":"m1","snapshot":{}}
+        {"type":"user","message":{"role":"user","content":"Write me a weather app"},"sessionId":"s1"}
+        {"type":"attachment","messageId":"m1","filePath":"/tmp/foo.png"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"I will create..."}]},"sessionId":"s1"}
+        {"type":"file-history-snapshot","messageId":"m2","snapshot":{}}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu-w1","name":"Write","input":{"file_path":"/weather.py","content":"print('hello')"}}]},"sessionId":"s1"}
+        {"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-w1","content":"File written"}]},"sessionId":"s1"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu-b1","name":"Bash","input":{"command":"python3 weather.py"}}]},"sessionId":"s1"}
+        {"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-b1","content":"hello"}]},"sessionId":"s1"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Here is your weather app!"}]},"sessionId":"s1"}
+        {"type":"system","sessionId":"s1","isMeta":false}
+        {"type":"user","message":{"role":"user","content":"<local-command-caveat>Caveat: ...</local-command-caveat>"},"isMeta":true}
+        {"type":"user","message":{"role":"user","content":"<bash-input>python3 weather.py</bash-input>"},"sessionId":"s1"}
+        {"type":"user","message":{"role":"user","content":"<bash-stdout>hello</bash-stdout><bash-stderr></bash-stderr>"},"sessionId":"s1"}
+        {"type":"file-history-snapshot","messageId":"m3","snapshot":{}}
+        {"type":"user","message":{"role":"user","content":"Add a location CLI flag"},"sessionId":"s1"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu-e1","name":"Edit","input":{"file_path":"/weather.py","old_string":"print","new_string":"import sys; print"}}]},"sessionId":"s1"}
+        {"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-e1","content":"File edited"}]},"sessionId":"s1"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Added location flag!"}]},"sessionId":"s1"}
+        {"type":"last-prompt","lastPrompt":"Add a location CLI flag","sessionId":"s1"}
+        {"type":"permission-mode","permissionMode":"bypassPermissions","sessionId":"s1"}
+        """
+
+        let messages = ChatViewModel.parseSessionJSONL(jsonl)
+
+        // Should produce 4 messages: user1, assistant1, user2, assistant2
+        #expect(messages.count == 4, "Expected 4 messages but got \\(messages.count)")
+        #expect(messages[0].role == .user)
+        #expect(messages[0].textContent == "Write me a weather app")
+        #expect(messages[1].role == .assistant)
+        // assistant1 should have: toolUse(Write), toolResult, toolUse(Bash), toolResult, text
+        #expect(messages[1].content.count == 5, "Turn 1 assistant should have 5 content items, got \\(messages[1].content.count)")
+        #expect(messages[2].role == .user)
+        #expect(messages[2].textContent == "Add a location CLI flag")
+        #expect(messages[3].role == .assistant)
+        // assistant2 should have: toolUse(Edit), toolResult, text
+        #expect(messages[3].content.count == 3)
+        #expect(messages[3].textContent == "Added location flag!")
+    }
+
+    @Test func convertJSONLToWisp_thenParseWispLog_roundTrip() {
+        // Verify the full round-trip: JSONL → convertJSONLToWisp → parseWispLog
+        // produces the same conversation structure as parseSessionJSONL
+        let jsonl = """
+        {"type":"permission-mode","permissionMode":"bypassPermissions","sessionId":"s1"}
+        {"type":"file-history-snapshot","messageId":"m1","snapshot":{}}
+        {"type":"user","message":{"role":"user","content":"Write me a weather app"},"sessionId":"s1"}
+        {"type":"attachment","messageId":"m1","filePath":"/tmp/foo.png"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"I will create..."}]},"sessionId":"s1"}
+        {"type":"file-history-snapshot","messageId":"m2","snapshot":{}}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu-w1","name":"Write","input":{"file_path":"/weather.py","content":"print('hello')"}}]},"sessionId":"s1"}
+        {"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-w1","content":"File written"}]},"sessionId":"s1"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu-b1","name":"Bash","input":{"command":"python3 weather.py"}}]},"sessionId":"s1"}
+        {"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-b1","content":"hello"}]},"sessionId":"s1"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Here is your weather app!"}]},"sessionId":"s1"}
+        {"type":"system","sessionId":"s1","isMeta":false}
+        {"type":"user","message":{"role":"user","content":"<local-command-caveat>Caveat: ...</local-command-caveat>"},"isMeta":true}
+        {"type":"user","message":{"role":"user","content":"<bash-input>python3 weather.py</bash-input>"},"sessionId":"s1"}
+        {"type":"user","message":{"role":"user","content":"<bash-stdout>hello</bash-stdout><bash-stderr></bash-stderr>"},"sessionId":"s1"}
+        {"type":"file-history-snapshot","messageId":"m3","snapshot":{}}
+        {"type":"user","message":{"role":"user","content":"Add a location CLI flag"},"sessionId":"s1"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu-e1","name":"Edit","input":{"file_path":"/weather.py","old_string":"print","new_string":"import sys; print"}}]},"sessionId":"s1"}
+        {"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-e1","content":"File edited"}]},"sessionId":"s1"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Added location flag!"}]},"sessionId":"s1"}
+        {"type":"last-prompt","lastPrompt":"Add a location CLI flag","sessionId":"s1"}
+        {"type":"permission-mode","permissionMode":"bypassPermissions","sessionId":"s1"}
+        """
+
+        let wispContent = ChatViewModel.convertJSONLToWisp(jsonl)
+        let (wispMessages, _) = ChatViewModel.parseWispLog(wispContent)
+
+        // Should produce same 4 messages as parseSessionJSONL
+        #expect(wispMessages.count == 4, "Round-trip produced \(wispMessages.count) messages, expected 4")
+        #expect(wispMessages[0].role == .user)
+        #expect(wispMessages[0].textContent == "Write me a weather app")
+        #expect(wispMessages[1].role == .assistant)
+        #expect(wispMessages[1].content.count == 5, "Turn 1 assistant should have 5 items, got \(wispMessages[1].content.count)")
+        #expect(wispMessages[2].role == .user)
+        #expect(wispMessages[2].textContent == "Add a location CLI flag")
+        #expect(wispMessages[3].role == .assistant)
+        #expect(wispMessages[3].content.count == 3)
+        #expect(wispMessages[3].textContent == "Added location flag!")
+    }
+
     // MARK: - claudeProjectPathEncoding
 
     @Test func claudeProjectPathEncoding_simpleProject() {

--- a/WispTests/ChatViewModelTests.swift
+++ b/WispTests/ChatViewModelTests.swift
@@ -1235,130 +1235,220 @@ struct ChatViewModelTests {
         #expect(card.result?.toolUseId == "tu-1")
     }
 
-    // MARK: - mergedWithLocalMessages
+    // MARK: - wispLogPath
 
-    @Test func mergedWithLocalMessages_preservesSubAgentToolCalls() throws {
-        // Local messages have sub-agent tool calls (streamed live); JSONL only has main-agent turns.
-        // The merge should keep local tool cards and use JSONL text if it's more complete.
-        let ctx = try makeModelContext()
-        let (vm, _) = makeChatViewModel(modelContext: ctx)
-
-        // Simulate locally-persisted assistant message with a sub-agent Bash call
-        let userMsg = ChatMessage(role: .user, content: [.text("do the thing")])
-        let subAgentCard = ToolUseCard(toolUseId: "tu-bash", toolName: "Bash", input: .object(["command": .string("ls")]))
-        let assistantMsg = ChatMessage(role: .assistant, content: [
-            .toolUse(subAgentCard),
-            .text("Partial text..."),   // truncated — app disconnected before full response
-        ])
-        vm.messages = [userMsg, assistantMsg]
-
-        // JSONL version: no Bash card, but complete final text
-        let jsonlUser = ChatMessage(role: .user, content: [.text("do the thing")])
-        let jsonlAssistant = ChatMessage(role: .assistant, content: [
-            .text("Complete response from Claude with all details."),
-        ])
-        let jsonlMessages = [jsonlUser, jsonlAssistant]
-
-        let result = vm.mergedWithLocalMessages(jsonlMessages)
-
-        #expect(result.count == 2)
-        let merged = result[1]
-        #expect(merged.role == .assistant)
-        // Sub-agent Bash tool call preserved
-        let hasToolUse = merged.content.contains { if case .toolUse = $0 { true } else { false } }
-        #expect(hasToolUse, "Sub-agent tool call should be preserved from local messages")
-        // Text updated to the longer JSONL version
-        #expect(merged.textContent == "Complete response from Claude with all details.")
+    @Test func wispLogPath_formatsCorrectly() {
+        let id = UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!
+        let path = ChatViewModel.wispLogPath(for: id)
+        #expect(path == "/home/sprite/.wisp/chats/12345678-1234-1234-1234-123456789abc.wisplog")
     }
 
-    @Test func mergedWithLocalMessages_fallsBackToJSONLWhenStructureDiffers() throws {
-        // If the conversation structures differ (different user message counts), fall back
-        // to the JSONL messages as-is. In practice this shouldn't happen — Claude can't
-        // create new user turns on its own — but it's a safety net for unexpected states.
-        let ctx = try makeModelContext()
-        let (vm, _) = makeChatViewModel(modelContext: ctx)
+    // MARK: - parseWispLog
 
-        let userMsg = ChatMessage(role: .user, content: [.text("first message")])
-        vm.messages = [userMsg]
+    @Test func parseWispLog_singleTurn() {
+        let ndjson = """
+        {"type":"wisp_user_prompt","text":"Hello","timestamp":"2026-01-01T00:00:00Z"}
+        {"type":"system","session_id":"sess-1","model":"claude-sonnet"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi there!"}]}}
+        {"type":"result","session_id":"sess-1","is_error":false}
+        """
 
-        // JSONL has an extra exchange
-        let jsonlMessages = [
-            ChatMessage(role: .user, content: [.text("first message")]),
-            ChatMessage(role: .assistant, content: [.text("reply")]),
-            ChatMessage(role: .user, content: [.text("follow-up")]),
-            ChatMessage(role: .assistant, content: [.text("final reply")]),
-        ]
+        let (messages, sessionId) = ChatViewModel.parseWispLog(ndjson)
 
-        let result = vm.mergedWithLocalMessages(jsonlMessages)
-
-        #expect(result.count == 4, "Should fall back to JSONL when structures differ")
+        #expect(messages.count == 2)
+        #expect(messages[0].role == .user)
+        #expect(messages[0].textContent == "Hello")
+        #expect(messages[1].role == .assistant)
+        #expect(messages[1].textContent == "Hi there!")
+        #expect(sessionId == "sess-1")
     }
 
-    @Test func mergedWithLocalMessages_preservesIntroTextBeforeToolCalls() throws {
-        // "Let me check…" → tool call → "Final response" — intro text must stay in
-        // position; only the last text block (which may be truncated) should be updated.
-        let ctx = try makeModelContext()
-        let (vm, _) = makeChatViewModel(modelContext: ctx)
+    @Test func parseWispLog_multiTurn() {
+        let ndjson = """
+        {"type":"wisp_user_prompt","text":"First message","timestamp":""}
+        {"type":"system","session_id":"sess-1","model":"claude-sonnet"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Reply 1"}]}}
+        {"type":"result","session_id":"sess-1","is_error":false}
+        {"type":"wisp_user_prompt","text":"Follow-up","timestamp":""}
+        {"type":"system","session_id":"sess-1","model":"claude-sonnet"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Reply 2"}]}}
+        {"type":"result","session_id":"sess-1","is_error":false}
+        """
 
-        let taskCard = ToolUseCard(toolUseId: "tu-task", toolName: "Task", input: .null)
-        let userMsg = ChatMessage(role: .user, content: [.text("do the thing")])
-        let assistantMsg = ChatMessage(role: .assistant, content: [
-            .text("Let me check on that..."),
-            .toolUse(taskCard),
-            .text("Partial fi"),  // truncated
-        ])
-        vm.messages = [userMsg, assistantMsg]
+        let (messages, sessionId) = ChatViewModel.parseWispLog(ndjson)
 
-        let jsonlMessages = [
-            ChatMessage(role: .user, content: [.text("do the thing")]),
-            ChatMessage(role: .assistant, content: [
-                .text("Let me check on that..."),
-                .toolUse(taskCard),
-                .text("Final response complete."),
-            ]),
-        ]
-
-        let result = vm.mergedWithLocalMessages(jsonlMessages)
-        let merged = result[1]
-
-        // Intro text stays first
-        guard case .text(let intro) = merged.content.first else {
-            Issue.record("Expected intro text as first content item"); return
-        }
-        #expect(intro == "Let me check on that...")
-        // Tool call stays second
-        guard case .toolUse = merged.content[1] else {
-            Issue.record("Expected toolUse as second content item"); return
-        }
-        // Final text updated from JSONL
-        guard case .text(let final) = merged.content[2] else {
-            Issue.record("Expected text as third content item"); return
-        }
-        #expect(final == "Final response complete.")
+        #expect(messages.count == 4)
+        #expect(messages[0].role == .user)
+        #expect(messages[0].textContent == "First message")
+        #expect(messages[1].role == .assistant)
+        #expect(messages[1].textContent == "Reply 1")
+        #expect(messages[2].role == .user)
+        #expect(messages[2].textContent == "Follow-up")
+        #expect(messages[3].role == .assistant)
+        #expect(messages[3].textContent == "Reply 2")
+        #expect(sessionId == "sess-1")
     }
 
-    @Test func mergedWithLocalMessages_keepsLocalTextIfAlreadyComplete() throws {
-        // If local text is already as long as the JSONL text, keep the local version unchanged.
-        let ctx = try makeModelContext()
-        let (vm, _) = makeChatViewModel(modelContext: ctx)
+    @Test func parseWispLog_toolUseAndResultLinkage() {
+        let ndjson = """
+        {"type":"wisp_user_prompt","text":"List files","timestamp":""}
+        {"type":"system","session_id":"sess-1","model":"claude-sonnet"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Let me check."},{"type":"tool_use","id":"tu-1","name":"Bash","input":{"command":"ls"}}]}}
+        {"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-1","content":"file1.txt\\nfile2.txt"}]}}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Found 2 files."}]}}
+        {"type":"result","session_id":"sess-1","is_error":false}
+        """
 
-        let subAgentCard = ToolUseCard(toolUseId: "tu-read", toolName: "Read", input: .object(["file_path": .string("/foo.txt")]))
-        let userMsg = ChatMessage(role: .user, content: [.text("read a file")])
-        let assistantMsg = ChatMessage(role: .assistant, content: [
-            .toolUse(subAgentCard),
-            .text("Here is the content of the file."),
-        ])
-        vm.messages = [userMsg, assistantMsg]
+        let (messages, _) = ChatViewModel.parseWispLog(ndjson)
 
-        let jsonlMessages = [
-            ChatMessage(role: .user, content: [.text("read a file")]),
-            ChatMessage(role: .assistant, content: [.text("Here is the content.")]),  // shorter
-        ]
+        #expect(messages.count == 2) // user + assistant
+        let assistant = messages[1]
+        #expect(assistant.role == .assistant)
 
-        let result = vm.mergedWithLocalMessages(jsonlMessages)
+        // Should have: text, toolUse, toolResult, text
+        #expect(assistant.content.count == 4)
+        guard case .text(let intro) = assistant.content[0] else {
+            Issue.record("Expected text"); return
+        }
+        #expect(intro == "Let me check.")
 
-        #expect(result[1].textContent == "Here is the content of the file.", "Local text should be kept when it's already complete")
-        let hasToolUse = result[1].content.contains { if case .toolUse = $0 { true } else { false } }
-        #expect(hasToolUse)
+        guard case .toolUse(let card) = assistant.content[1] else {
+            Issue.record("Expected toolUse"); return
+        }
+        #expect(card.toolName == "Bash")
+        #expect(card.toolUseId == "tu-1")
+
+        guard case .toolResult(let result) = assistant.content[2] else {
+            Issue.record("Expected toolResult"); return
+        }
+        #expect(result.toolUseId == "tu-1")
+        #expect(result.toolName == "Bash")
+
+        // Tool use card should be linked to its result
+        #expect(card.result != nil)
+        #expect(card.result?.toolUseId == "tu-1")
+
+        guard case .text(let outro) = assistant.content[3] else {
+            Issue.record("Expected trailing text"); return
+        }
+        #expect(outro == "Found 2 files.")
+    }
+
+    @Test func parseWispLog_consecutiveTextMerging() {
+        // Multiple text blocks in the same assistant event should be merged
+        let ndjson = """
+        {"type":"wisp_user_prompt","text":"Hello","timestamp":""}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Part 1 "},{"type":"text","text":"Part 2"}]}}
+        {"type":"result","session_id":"sess-1","is_error":false}
+        """
+
+        let (messages, _) = ChatViewModel.parseWispLog(ndjson)
+
+        #expect(messages.count == 2)
+        #expect(messages[1].textContent == "Part 1 Part 2")
+    }
+
+    @Test func parseWispLog_corruptLinesSkipped() {
+        let ndjson = """
+        {"type":"wisp_user_prompt","text":"Hello","timestamp":""}
+        not valid json at all
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Works fine"}]}}
+        {"truncated
+        {"type":"result","session_id":"sess-1","is_error":false}
+        """
+
+        let (messages, _) = ChatViewModel.parseWispLog(ndjson)
+
+        #expect(messages.count == 2)
+        #expect(messages[1].textContent == "Works fine")
+    }
+
+    @Test func parseWispLog_emptyInput() {
+        let (messages, sessionId) = ChatViewModel.parseWispLog("")
+        #expect(messages.isEmpty)
+        #expect(sessionId == nil)
+    }
+
+    @Test func parseWispLog_trailingAssistantWithoutResult() {
+        // If stream was interrupted before result event, trailing assistant should still be captured
+        let ndjson = """
+        {"type":"wisp_user_prompt","text":"Hello","timestamp":""}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I was saying..."}]}}
+        """
+
+        let (messages, _) = ChatViewModel.parseWispLog(ndjson)
+
+        #expect(messages.count == 2)
+        #expect(messages[1].role == .assistant)
+        #expect(messages[1].textContent == "I was saying...")
+    }
+
+    // MARK: - convertJSONLToWisp
+
+    @Test func convertJSONLToWisp_userPromptString() {
+        let jsonl = """
+        {"type":"user","message":{"role":"user","content":"Hello world"},"session_id":"s1"}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi!"}]},"session_id":"s1"}
+        """
+
+        let wisp = ChatViewModel.convertJSONLToWisp(jsonl)
+        let lines = wisp.split(separator: "\n")
+
+        #expect(lines.count == 2)
+        // First line should be a wisp_user_prompt
+        #expect(lines[0].contains("wisp_user_prompt"))
+        #expect(lines[0].contains("Hello world"))
+        // Second line should be passed through
+        #expect(lines[1].contains("assistant"))
+    }
+
+    @Test func convertJSONLToWisp_userPromptTextBlocks() {
+        let jsonl = """
+        {"type":"user","message":{"role":"user","content":[{"type":"text","text":"Block prompt"}]},"session_id":"s1"}
+        """
+
+        let wisp = ChatViewModel.convertJSONLToWisp(jsonl)
+
+        #expect(wisp.contains("wisp_user_prompt"))
+        #expect(wisp.contains("Block prompt"))
+    }
+
+    @Test func convertJSONLToWisp_toolResultsPassThrough() {
+        let jsonl = """
+        {"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-1","content":"output"}]},"session_id":"s1"}
+        """
+
+        let wisp = ChatViewModel.convertJSONLToWisp(jsonl)
+
+        // Should NOT be converted to wisp_user_prompt — pass through verbatim
+        #expect(!wisp.contains("wisp_user_prompt"))
+        #expect(wisp.contains("tool_result"))
+    }
+
+    @Test func convertJSONLToWisp_metaEntriesSkipped() {
+        let jsonl = """
+        {"type":"user","message":{"role":"user","content":"real prompt"},"session_id":"s1"}
+        {"type":"user","message":{"role":"user","content":[{"type":"text","text":"skill injection"}]},"session_id":"s1","isMeta":true}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"response"}]},"session_id":"s1"}
+        """
+
+        let wisp = ChatViewModel.convertJSONLToWisp(jsonl)
+        let lines = wisp.split(separator: "\n")
+
+        #expect(lines.count == 2) // user prompt + assistant, meta skipped
+    }
+
+    @Test func convertJSONLToWisp_systemAndResultPassThrough() {
+        let jsonl = """
+        {"type":"system","session_id":"s1","model":"claude-sonnet"}
+        {"type":"result","session_id":"s1","is_error":false}
+        """
+
+        let wisp = ChatViewModel.convertJSONLToWisp(jsonl)
+        let lines = wisp.split(separator: "\n")
+
+        #expect(lines.count == 2)
+        #expect(lines[0].contains("system"))
+        #expect(lines[1].contains("result"))
     }
 }


### PR DESCRIPTION
## Summary

- **Tees streaming NDJSON output** to `/home/sprite/.wisp/chats/{chatId}.wisplog` — one self-contained file per chat that captures the full stream including sub-agent tool calls
- **Writes custom `wisp_user_prompt` events** before each Claude invocation (user prompts aren't in the stream output, so we add them to make the log file self-contained)
- **New `parseWispLog` parser** (~80 lines) replaces the 120-line `parseSessionJSONL` for restore — uses `ClaudeStreamEvent` types directly, no JSONL-specific model types needed
- **Converts imported JSONL sessions to wisp format** on first select via `convertJSONLToWisp`, so all future loads use one code path
- **Cleans up `.wisplog` files** on chat delete, close, and clear all
- **Removes `mergedWithLocalMessages`** — no longer needed since the tee'd stream captures everything (Claude's internal JSONL misses sub-agent calls stored in separate files)
- **Removes `loadRemoteHistory`** — replaced by `loadFromWispLog` + `importJSONLSession`
- **Keeps `fetchRemoteSessions` and `parseSessionJSONL`** for discovering and importing legacy JSONL sessions
- **Falls back to JSONL** in `restoreFromSessionFile` for chats that predate wisp log files

## Test plan

- [x] 13 new tests for `parseWispLog`, `convertJSONLToWisp`, and `wispLogPath` (all passing)
- [x] Build succeeds, all 297 tests pass
- [x] Send a message → verify `.wisplog` file created on sprite with user_prompt + stream events
- [x] Send follow-up → verify file is appended to (multi-turn)
- [x] Kill app, reopen → verify chat restores from wisp file
- [x] Close chat → verify wisp file deleted from sprite
- [x] Delete chat → verify wisp file deleted from sprite
- [x] Import a remote JSONL session → verify wisp file created, chat displays correctly
- [x] Existing chat without wisp file → verify JSONL fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)