### PR TITLE
Improve chat navigation UX: last-used subtitle, resume action, clock indicator

### DIFF
--- a/Wisp/Views/Dashboard/DashboardView.swift
+++ b/Wisp/Views/Dashboard/DashboardView.swift
@@ -6,6 +6,19 @@ enum SpriteSortOrder: String, CaseIterable {
     case newest = "Newest"
 }
 
+/// Navigation target for the iPhone NavigationStack.
+/// Carries an optional resumeChatId so "Resume Chat" swipe actions can jump
+/// directly into a specific chat instead of landing on the overview.
+struct SpriteNavTarget: Hashable {
+    let spriteId: String
+    let resumeChatId: UUID?
+
+    init(_ spriteId: String, resumeChatId: UUID? = nil) {
+        self.spriteId = spriteId
+        self.resumeChatId = resumeChatId
+    }
+}
+
 struct DashboardView: View {
     @Environment(SpritesAPIClient.self) private var apiClient
     @Environment(ChatSessionManager.self) private var chatSessionManager
@@ -17,6 +30,10 @@ struct DashboardView: View {
     @State private var selectedTab: SpriteTab = .chat
     @State private var sortOrder: SpriteSortOrder = .newest
     @State private var showSettings = false
+    // iPhone: programmatic navigation path (lets swipe actions push directly to chat)
+    @State private var navPath = NavigationPath()
+    // iPad: flag set by "Resume Chat" action so onChange skips defaulting to overview
+    @State private var pendingChatOpen = false
 
     private var sortedSprites: [Sprite] {
         switch sortOrder {
@@ -77,6 +94,19 @@ struct DashboardView: View {
                 .tint(.red)
             }
             .swipeActions(edge: .leading) {
+                Button {
+                    if selectedSpriteID == sprite.id {
+                        // Already selected in the split view — just switch to the chat tab directly.
+                        selectedTab = .chat
+                    } else {
+                        pendingChatOpen = true
+                        selectedSpriteID = sprite.id
+                    }
+                } label: {
+                    Label("Resume Chat", systemImage: "arrow.uturn.right")
+                }
+                .tint(.indigo)
+
                 if (sprite.status == .warm || sprite.status == .cold) && !viewModel.wakingSprites.contains(sprite.name) {
                     Button {
                         Task { await viewModel.wakeSprite(sprite, apiClient: apiClient) }
@@ -87,6 +117,17 @@ struct DashboardView: View {
                 }
             }
             .contextMenu {
+                Button {
+                    if selectedSpriteID == sprite.id {
+                        selectedTab = .chat
+                    } else {
+                        pendingChatOpen = true
+                        selectedSpriteID = sprite.id
+                    }
+                } label: {
+                    Label("Resume Last Chat", systemImage: "arrow.uturn.right")
+                }
+
                 if (sprite.status == .warm || sprite.status == .cold) && !viewModel.wakingSprites.contains(sprite.name) {
                     Button {
                         Task { await viewModel.wakeSprite(sprite, apiClient: apiClient) }
@@ -100,16 +141,6 @@ struct DashboardView: View {
                     Label("Delete", systemImage: "trash")
                 }
             }
-            .confirmationDialog("Delete Sprite?", isPresented: .init(
-                get: { viewModel.spriteToDelete?.id == sprite.id },
-                set: { if !$0 { viewModel.spriteToDelete = nil } }
-            )) {
-                Button("Delete", role: .destructive) {
-                    Task { await viewModel.deleteSprite(sprite, apiClient: apiClient) }
-                }
-            } message: {
-                Text("This will permanently delete \"\(sprite.name)\". This action cannot be undone.")
-            }
             .id(sprite.id)
         }
     }
@@ -118,7 +149,7 @@ struct DashboardView: View {
     @ViewBuilder
     private var iPhoneSpriteListRows: some View {
         ForEach(sortedSprites) { sprite in
-            NavigationLink(value: sprite.id) {
+            NavigationLink(value: SpriteNavTarget(sprite.id)) {
                 SpriteRowView(
                     sprite: sprite,
                     isPlain: false,
@@ -133,6 +164,19 @@ struct DashboardView: View {
                 .tint(.red)
             }
             .swipeActions(edge: .leading) {
+                Button {
+                    let name = sprite.name
+                    let descriptor = FetchDescriptor<SpriteChat>(
+                        predicate: #Predicate { $0.spriteName == name && !$0.isClosed },
+                        sortBy: [SortDescriptor(\.lastUsed, order: .reverse)]
+                    )
+                    let resumeChatId = (try? modelContext.fetch(descriptor))?.first?.id
+                    navPath.append(SpriteNavTarget(sprite.id, resumeChatId: resumeChatId))
+                } label: {
+                    Label("Resume Chat", systemImage: "arrow.uturn.right")
+                }
+                .tint(.indigo)
+
                 if (sprite.status == .warm || sprite.status == .cold) && !viewModel.wakingSprites.contains(sprite.name) {
                     Button {
                         Task { await viewModel.wakeSprite(sprite, apiClient: apiClient) }
@@ -143,6 +187,18 @@ struct DashboardView: View {
                 }
             }
             .contextMenu {
+                Button {
+                    let name = sprite.name
+                    let descriptor = FetchDescriptor<SpriteChat>(
+                        predicate: #Predicate { $0.spriteName == name && !$0.isClosed },
+                        sortBy: [SortDescriptor(\.lastUsed, order: .reverse)]
+                    )
+                    let resumeChatId = (try? modelContext.fetch(descriptor))?.first?.id
+                    navPath.append(SpriteNavTarget(sprite.id, resumeChatId: resumeChatId))
+                } label: {
+                    Label("Resume Last Chat", systemImage: "arrow.uturn.right")
+                }
+
                 if (sprite.status == .warm || sprite.status == .cold) && !viewModel.wakingSprites.contains(sprite.name) {
                     Button {
                         Task { await viewModel.wakeSprite(sprite, apiClient: apiClient) }
@@ -156,16 +212,6 @@ struct DashboardView: View {
                     Label("Delete", systemImage: "trash")
                 }
             }
-            .confirmationDialog("Delete Sprite?", isPresented: .init(
-                get: { viewModel.spriteToDelete?.id == sprite.id },
-                set: { if !$0 { viewModel.spriteToDelete = nil } }
-            )) {
-                Button("Delete", role: .destructive) {
-                    Task { await viewModel.deleteSprite(sprite, apiClient: apiClient) }
-                }
-            } message: {
-                Text("This will permanently delete \"\(sprite.name)\". This action cannot be undone.")
-            }
             .listRowSeparator(.hidden)
             .listRowBackground(Color.clear)
             .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
@@ -175,7 +221,7 @@ struct DashboardView: View {
 
     // iPhone: explicit NavigationStack so SpriteDetailView can push further views
     private var iPhoneContent: some View {
-        NavigationStack {
+        NavigationStack(path: $navPath) {
             Group {
                 if viewModel.sprites.isEmpty && !viewModel.isLoading {
                     ContentUnavailableView(
@@ -196,10 +242,24 @@ struct DashboardView: View {
             }
             .navigationTitle("Sprites")
             .toolbar { dashboardToolbar }
-            .navigationDestination(for: String.self) { id in
-                if let sprite = sortedSprites.first(where: { $0.id == id }) {
-                    SpriteDetailView(sprite: sprite, selectedTab: $selectedTab)
-                        .id(id)
+            .confirmationDialog("Delete Sprite?", isPresented: .init(
+                get: { viewModel.spriteToDelete != nil },
+                set: { if !$0 { viewModel.spriteToDelete = nil } }
+            )) {
+                Button("Delete", role: .destructive) {
+                    if let sprite = viewModel.spriteToDelete {
+                        Task { await viewModel.deleteSprite(sprite, apiClient: apiClient) }
+                    }
+                }
+            } message: {
+                if let sprite = viewModel.spriteToDelete {
+                    Text("This will permanently delete \"\(sprite.name)\". This action cannot be undone.")
+                }
+            }
+            .navigationDestination(for: SpriteNavTarget.self) { target in
+                if let sprite = sortedSprites.first(where: { $0.id == target.spriteId }) {
+                    SpriteDetailView(sprite: sprite, selectedTab: $selectedTab, initialChatId: target.resumeChatId)
+                        .id(target.spriteId)
                 }
             }
         }
@@ -228,6 +288,23 @@ struct DashboardView: View {
                     }
                     .navigationTitle("Sprites")
                     .toolbar { dashboardToolbar }
+                    // .alert (not .confirmationDialog) — regular size class becomes a popover
+                    // when anchored, but .alert is a centred modal regardless of attachment point.
+                    .alert("Delete Sprite?", isPresented: .init(
+                        get: { viewModel.spriteToDelete != nil },
+                        set: { if !$0 { viewModel.spriteToDelete = nil } }
+                    )) {
+                        Button("Delete", role: .destructive) {
+                            if let sprite = viewModel.spriteToDelete {
+                                Task { await viewModel.deleteSprite(sprite, apiClient: apiClient) }
+                            }
+                        }
+                        Button("Cancel", role: .cancel) {}
+                    } message: {
+                        if let sprite = viewModel.spriteToDelete {
+                            Text("This will permanently delete \"\(sprite.name)\". This action cannot be undone.")
+                        }
+                    }
                 } detail: {
                     if let id = selectedSpriteID, let selectedSprite = sortedSprites.first(where: { $0.id == id }) {
                         SpriteDetailView(sprite: selectedSprite, selectedTab: $selectedTab)
@@ -250,7 +327,12 @@ struct DashboardView: View {
             }
         }
         .onChange(of: selectedSpriteID) { _, _ in
-            selectedTab = .overview
+            if pendingChatOpen {
+                selectedTab = .chat
+                pendingChatOpen = false
+            } else {
+                selectedTab = .overview
+            }
         }
         .task {
             await viewModel.loadSprites(apiClient: apiClient)

--- a/Wisp/Views/Dashboard/SpriteRowView.swift
+++ b/Wisp/Views/Dashboard/SpriteRowView.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 struct SpriteRowView: View {
@@ -6,7 +7,21 @@ struct SpriteRowView: View {
     var isSelected: Bool = false
     var hasUnreadChats: Bool = false
 
+    @Query private var recentChats: [SpriteChat]
     @State private var isPulsing = false
+
+    init(sprite: Sprite, isPlain: Bool = false, isSelected: Bool = false, hasUnreadChats: Bool = false) {
+        self.sprite = sprite
+        self.isPlain = isPlain
+        self.isSelected = isSelected
+        self.hasUnreadChats = hasUnreadChats
+        let name = sprite.name
+        _recentChats = Query(
+            filter: #Predicate<SpriteChat> { $0.spriteName == name && !$0.isClosed },
+            sort: \.lastUsed,
+            order: .reverse
+        )
+    }
 
     var body: some View {
         if isPlain {
@@ -43,7 +58,11 @@ struct SpriteRowView: View {
                     .fontWeight(.medium)
                     .foregroundStyle(isPlain ? AnyShapeStyle(.primary) : AnyShapeStyle(Color.primary))
 
-                if let createdAt = sprite.createdAt {
+                if let chat = recentChats.first {
+                    Text("\(chat.displayName) · \(chat.lastUsed.relativeFormatted)")
+                        .font(.caption)
+                        .foregroundStyle(isPlain ? AnyShapeStyle(.secondary) : AnyShapeStyle(Color.secondary))
+                } else if let createdAt = sprite.createdAt {
                     Text(createdAt.relativeFormatted)
                         .font(.caption)
                         .foregroundStyle(isPlain ? AnyShapeStyle(.secondary) : AnyShapeStyle(Color.secondary))
@@ -100,6 +119,7 @@ private func mockSprite(id: String = "s1", name: String, status: String) -> Spri
         SpriteRowView(sprite: mockSprite(id: "s4", name: "busy-sprite", status: "running"), hasUnreadChats: true)
     }
     .padding()
+    .modelContainer(for: [SpriteChat.self, SpriteSession.self], inMemory: true)
 }
 
 #Preview("Plain style (iPad sidebar)") {
@@ -109,4 +129,5 @@ private func mockSprite(id: String = "s1", name: String, status: String) -> Spri
         SpriteRowView(sprite: mockSprite(id: "s3", name: "old-project", status: "cold"), isPlain: true)
         SpriteRowView(sprite: mockSprite(id: "s4", name: "busy-sprite", status: "running"), isPlain: true, hasUnreadChats: true)
     }
+    .modelContainer(for: [SpriteChat.self, SpriteSession.self], inMemory: true)
 }

--- a/Wisp/Views/SpriteDetail/SpriteDetailView.swift
+++ b/Wisp/Views/SpriteDetail/SpriteDetailView.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 struct SpriteDetailView: View {
     let sprite: Sprite
+    let initialChatId: UUID?
     @Binding var selectedTab: SpriteTab
     @State private var chatListViewModel: SpriteChatListViewModel
     @State private var chatViewModel: ChatViewModel?
@@ -20,8 +21,9 @@ struct SpriteDetailView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.horizontalSizeClass) private var sizeClass
 
-    init(sprite: Sprite, selectedTab: Binding<SpriteTab>) {
+    init(sprite: Sprite, selectedTab: Binding<SpriteTab>, initialChatId: UUID? = nil) {
         self.sprite = sprite
+        self.initialChatId = initialChatId
         _selectedTab = selectedTab
         _chatListViewModel = State(initialValue: SpriteChatListViewModel(spriteName: sprite.name))
         _checkpointsViewModel = State(initialValue: CheckpointsViewModel(spriteName: sprite.name))
@@ -268,8 +270,16 @@ struct SpriteDetailView: View {
                 chatListViewModel.createChat(modelContext: modelContext)
             }
 
-            // Initialize chat VM for active chat
-            if let active = chatListViewModel.activeChat {
+            // If a specific chat was requested (e.g. via "Resume Chat" swipe action),
+            // switch to it and — on iPhone — push straight to ChatView, bypassing overview.
+            if let chatId = initialChatId,
+               let chat = chatListViewModel.chats.first(where: { $0.id == chatId }) {
+                markChatRead(chat)
+                switchToChat(chat)
+                if sizeClass != .regular {
+                    showingChat = true
+                }
+            } else if let active = chatListViewModel.activeChat {
                 switchToChat(active)
             }
         }

--- a/Wisp/Views/SpriteDetail/SpriteNavigationPanel.swift
+++ b/Wisp/Views/SpriteDetail/SpriteNavigationPanel.swift
@@ -92,6 +92,11 @@ struct SpriteNavigationPanel: View {
                 Image(systemName: "archivebox")
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
+            } else if chat.id == openChats.first?.id {
+                Image(systemName: "clock")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .accessibilityLabel("Most recently used")
             }
         }
         .contextMenu {


### PR DESCRIPTION
## Summary

- **Last-used chat subtitle in sprite rows**: `SpriteRowView` now shows the most recently used open chat name and relative time as a subtitle (e.g. "Chat #3 · 8m ago"), using a `@Query` with a dynamic predicate. Falls back to sprite creation date when no chats exist.

- **"Resume Chat" swipe action + context menu**: Both iPhone and iPad sprite rows get a leading swipe action and context menu item to jump directly to the last-used chat. On iPhone this uses a `NavigationPath`-based `SpriteNavTarget` to push `SpriteDetailView` carrying the chat ID, then immediately pushes `ChatView` on appear — bypassing the overview entirely. On iPad it skips the `onChange` reset to `.overview` via a `pendingChatOpen` flag and jumps straight to the chat tab.

- **Clock indicator in iPad nav panel**: The most recently used open chat in `SpriteNavigationPanel` gets a subtle tertiary clock SF Symbol — a visual anchor for "where you left off" in the sidebar.

- **Fix pre-existing CLAUDE.md violations in `DashboardView`**: Moved `.confirmationDialog` off `ForEach` rows onto stable ancestor views (prevents immediate dismiss on list re-render). Switched the iPad/Mac delete confirmation to `.alert` since `.confirmationDialog` becomes an anchored popover in regular size class.

## Test plan

- [ ] iPhone: sprite row subtitle shows last chat name + relative time; falls back to creation date for sprites with no chats
- [ ] iPhone: leading swipe "Resume Chat" pushes directly into `ChatView` for the last-used chat, skipping overview
- [ ] iPhone: normal row tap still lands on overview as before
- [ ] iPad: leading swipe "Resume Chat" selects sprite and switches to chat tab
- [ ] iPad: "Resume Chat" on already-selected sprite switches tab without navigating away
- [ ] iPad: clock icon appears next to most recently used open chat in nav panel; disappears when that chat gets an unread indicator
- [ ] iPad/Mac: delete confirmation appears as a centred `.alert`, not an anchored popover
- [ ] Both: delete confirmation no longer dismisses immediately when the sprite list re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)