### PR TITLE
Fix chat input lag in long chats

### DIFF
--- a/Wisp/Views/SpriteDetail/Chat/ChatInputBar.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatInputBar.swift
@@ -16,9 +16,11 @@ struct ChatInputBar: View {
     var onRemoveAttachment: ((AttachedFile) -> Void)? = nil
     var lastUploadedFileName: String? = nil
     var onStash: (() -> Void)? = nil
+    var onTextChange: (() -> Void)? = nil
     var isFocused: FocusState<Bool>.Binding
 
     @State private var showStopConfirmation = false
+    @State private var saveDraftTask: Task<Void, Never>?
 
     private var isEmpty: Bool {
         text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && attachedFiles.isEmpty
@@ -113,6 +115,15 @@ struct ChatInputBar: View {
         .padding(.horizontal)
         .padding(.vertical, 4)
         .padding(.bottom, isRunningOnMac ? 12 : 0)
+        .onChange(of: text) {
+            guard let onTextChange else { return }
+            saveDraftTask?.cancel()
+            saveDraftTask = Task {
+                try? await Task.sleep(for: .milliseconds(500))
+                guard !Task.isCancelled else { return }
+                onTextChange()
+            }
+        }
     }
 
 }

--- a/Wisp/Views/SpriteDetail/Chat/ChatView.swift
+++ b/Wisp/Views/SpriteDetail/Chat/ChatView.swift
@@ -27,13 +27,13 @@ struct ChatView: View {
 
     // Quick Actions
     @State private var quickActionsViewModel: QuickActionsViewModel?
-    @State private var saveDraftTask: Task<Void, Never>?
+
     @State private var showChatSwitcher = false
 
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                VStack(spacing: 12) {
+                LazyVStack(spacing: 12) {
                     if viewModel.messages.isEmpty && !isReadOnly && !viewModel.usesWorktree {
                         SessionSuggestionsView(
                             sessions: viewModel.remoteSessions,
@@ -150,14 +150,6 @@ struct ChatView: View {
                 viewModel.saveDraft(modelContext: modelContext)
             }
         }
-        .onChange(of: viewModel.inputText) {
-            saveDraftTask?.cancel()
-            saveDraftTask = Task {
-                try? await Task.sleep(for: .milliseconds(500))
-                guard !Task.isCancelled else { return }
-                viewModel.saveDraft(modelContext: modelContext)
-            }
-        }
         .onChange(of: viewModel.attachedFiles.count) {
             viewModel.saveDraft(modelContext: modelContext)
         }
@@ -190,6 +182,7 @@ struct ChatView: View {
                     },
                     lastUploadedFileName: viewModel.lastUploadedFileName,
                     onStash: { viewModel.stashDraft() },
+                    onTextChange: { viewModel.saveDraft(modelContext: modelContext) },
                     isFocused: $isInputFocused
                 )
             }


### PR DESCRIPTION
## Summary

- Replace `VStack` with `LazyVStack` in the chat message list so only visible messages are rendered, instead of all N messages on every re-render
- Move the `inputText` draft-save `onChange` observer from `ChatView` into `ChatInputBar`, so that `ChatView` no longer re-renders on every keystroke

## Root causes

**1. Eager `VStack`** — the message list used `VStack`, which renders every message upfront regardless of visibility. With a long chat, any re-render (including keystrokes) caused SwiftUI to evaluate the full message list.

**2. `ChatView` observed `inputText`** — `.onChange(of: viewModel.inputText)` in `ChatView.body` registered `ChatView` as an observer of `inputText`. Every keystroke invalidated `ChatView.body`, triggering a full re-evaluation of all those message views. With a long chat, this was proportionally more expensive.

## Test plan

- [ ] Type in the input bar with a long chat open — should feel responsive with no lag
- [ ] Scroll up through history — older messages load on demand correctly
- [ ] Send a message and verify streaming still auto-scrolls to bottom
- [ ] Draft auto-save still fires (500ms debounce) when typing
- [ ] Stop/interrupt still works during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)